### PR TITLE
Feature Draft: Docker local development environment.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ We have a [Code of Conduct](https://github.com/phase2/outline/blob/next/CODE_OF_
 
 Run the following steps to ensure your environment is installed and up to date. This assumes you are using [NVM](https://github.com/nvm-sh/nvm) locally to manage your NPM version(s).
 
+*If you would like to use Docker containers, see below.*
+
 ```bash
 # Checkout the repository.
 git clone git@github.com:phase2/outline.git && cd outline
@@ -17,6 +19,27 @@ git clone git@github.com:phase2/outline.git && cd outline
 nvm use
 # Install project dependencies.
 yarn install
+```
+
+### Docker Compose local development
+
+You can use Docker Desktop to create a container which contains the dependencies to build the project.
+
+```bash
+# Create / Recreate the containers.
+docker compose up -d
+
+# SSH into the container.
+docker compose exec node bash
+
+# Install the project dependencies.
+yarn install
+
+# Disconnect from the container
+exit
+
+# Shut down the container
+docker compose down
 ```
 
 ## Storybook Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ Primary component development is done and demonstrated via [Storybook](https://s
 yarn start
 ```
 
+Load [http://localhost:6006](http://localhost:6006) in a browser.
+
 ## Testing
 
 All PRs require passing tests before the PR will be reviewed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+
+services:
+  node:
+    # See `.nvmrc`
+    image: "node:14"
+    container_name: node_outline
+    user: "node"
+    working_dir: /home/node/app
+    volumes:
+      - .:/home/node/app
+    ports:
+      # See `storybook.dev` in `package.json`
+      - "6006:6006"
+    # Allow us to log in and keep the connection open.
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
-version: "3.8"
+version: '3.8'
 
 services:
   node:
     # See `.nvmrc`
-    image: "node:14"
+    image: 'node:14'
     container_name: node_outline
-    user: "node"
+    user: 'node'
     working_dir: /home/node/app
     volumes:
       - .:/home/node/app
     ports:
       # See `storybook.dev` in `package.json`
-      - "6006:6006"
+      - '6006:6006'
     # Allow us to log in and keep the connection open.
     tty: true


### PR DESCRIPTION
I sometimes (depends on the project) like to use Docker environments for local development.

This would be completely optional and the environments themselves are very simple. Would others find this useful?

Tested
```
yarn install
yarn start
yarn lint
yarn fmt
```

They all seem to work from the container. `yarn install` is probably a little slow since it isn't using NFS or anything.

This probably cannot be committed as-is, particularly since it will conflict with #36.