### PR TITLE
Feature: #45 Modal.

### DIFF
--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -10,7 +10,7 @@
 }
 
 #container {
-  @apply overflow-y-auto rounded-sm max-h-screen bg-neutral-white max-w-full md:max-w-quarter-screen-w;
+  @apply overflow-y-auto rounded-sm h-screen bg-neutral-white max-w-full md:max-w-quarter-screen-w md:h-auto;
   min-width: 320px;
 
   #overlay.medium & {

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+
+#overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#container {
+  background-color: #fff;
+  min-width: 320px;
+  max-width: 500px;
+  max-height: 100vh;
+  border-radius: 4px;
+  overflow-y: auto;
+}
+
+#header {
+  position: relative;
+  padding: 1.62rem 1.62rem 0 1.62rem;
+}
+
+#close {
+  background: transparent;
+  border: 0;
+  position: absolute;
+  top: 0.62rem;
+  right: 0.62rem;
+}
+
+/* We need a double slash on the unicode because of templates later. */
+#close:before { content: "\\2715"; }
+
+#main {
+  padding: 1.62rem;
+}

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -10,9 +10,16 @@
 }
 
 #container {
-  @apply overflow-y-auto rounded-sm max-h-screen bg-neutral-white;
+  @apply overflow-y-auto rounded-sm max-h-screen bg-neutral-white max-w-full md:max-w-quarter-screen-w;
   min-width: 320px;
-  max-width: 500px;
+
+  #overlay.medium & {
+    @apply md:max-w-half-screen-w;
+  }
+
+  #overlay.full-screen & {
+    @apply w-full-screen-w max-w-full-screen-w h-full-screen-h md:w-full-screen-w md:max-w-full-screen-w;
+  }
 }
 
 #header {

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -38,3 +38,7 @@
 #main {
   @apply p-6;
 }
+
+#accessibility-description {
+  @apply hidden;
+}

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -1,7 +1,3 @@
-* {
-  @apply box-border;
-}
-
 #overlay {
   @apply fixed top-0 left-0 right-0 bottom-0 z-50 flex items-center justify-center bg-opacity-60 bg-neutral-black;
 

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 99999;
 }
 
 #container {

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -3,11 +3,14 @@
 }
 
 #overlay {
-  @apply fixed top-0 left-0 right-0 bottom-0 z-50 flex items-center justify-center bg-black bg-opacity-6;
+  @apply fixed top-0 left-0 right-0 bottom-0 z-50 flex items-center justify-center bg-opacity-60 bg-neutral-black;
+
+  /* Tailwind background opacity with customizations wasn't working.\`bg-opacity-60 bg-neutral-black\` */
+  background-color: rgb(0, 0, 0, var(--tw-bg-opacity));
 }
 
 #container {
-  @apply overflow-y-auto bg-white rounded-sm min-h-screen;
+  @apply overflow-y-auto rounded-sm max-h-screen bg-neutral-white;
   min-width: 320px;
   max-width: 500px;
 }
@@ -17,7 +20,7 @@
 }
 
 #close {
-  @apply absolute bg-transparent border-0 top-2.5 right-2.5;
+  @apply absolute border-0 top-2.5 right-2.5 bg-neutral-transparent;
 }
 
 /* We need a double slash on the unicode because of templates later. */

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -1,40 +1,23 @@
 * {
-  box-sizing: border-box;
+  @apply box-border;
 }
 
 #overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 99999;
+  @apply fixed top-0 left-0 right-0 bottom-0 z-50 flex items-center justify-center bg-black bg-opacity-6;
 }
 
 #container {
-  background-color: #fff;
+  @apply overflow-y-auto bg-white rounded-sm min-h-screen;
   min-width: 320px;
   max-width: 500px;
-  max-height: 100vh;
-  border-radius: 4px;
-  overflow-y: auto;
 }
 
 #header {
-  position: relative;
-  padding: 1.62rem 1.62rem 0 1.62rem;
+  @apply relative px-6 pt-6;
 }
 
 #close {
-  background: transparent;
-  border: 0;
-  position: absolute;
-  top: 0.62rem;
-  right: 0.62rem;
+  @apply absolute bg-transparent border-0 top-2.5 right-2.5;
 }
 
 /* We need a double slash on the unicode because of templates later. */
@@ -43,5 +26,5 @@
 }
 
 #main {
-  padding: 1.62rem;
+  @apply p-6;
 }

--- a/src/components/base/outline-modal/outline-modal.css
+++ b/src/components/base/outline-modal/outline-modal.css
@@ -8,7 +8,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0,0,0,0.6);
+  background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,7 +37,9 @@
 }
 
 /* We need a double slash on the unicode because of templates later. */
-#close:before { content: "\\2715"; }
+#close:before {
+  content: '\\2715';
+}
 
 #main {
   padding: 1.62rem;

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -24,6 +24,14 @@ export default {
       },
       // We aren't setting a control type here so we can edit the value using the infered object.
     },
+    accessibilityDescription: {
+      name: 'slot="outline-modal--accessibility-description"',
+      description: 'An description for accessibility. It is not visible.',
+      table: {
+        category: 'Slots',
+      },
+      // We aren't setting a control type here so we can edit the value using the infered object.
+    },
     // This is the modal content.
     // We aren't setting a control type here so we can edit the value using the infered object.
     defaultSlot: {
@@ -45,6 +53,9 @@ export default {
         component: `
 ## Accessibility
 
+Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html).
+
+- Modal uses full screen on small devices
 - If a trigger is supplied as a slot, that element can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
 - The \`Escape\` button can be used to close the modal
 - The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
@@ -77,6 +88,7 @@ You can also manually trigger the modal with the \`.open()\` method. Similarly, 
 <outline-modal size="{{ size }}">
   <outline-link slot="outline-modal--trigger">{{ triggerSlot}}</outline-link>
   <outline-heading slot="outline-modal--header">{{ headerSlot}}</outline-heading>
+  <p slot="outline-modal--accessibility-description">{{ accessibilityDescription }}</p>
   {{ defaultSlot }}
 </outline-modal>
         `,
@@ -88,13 +100,14 @@ You can also manually trigger the modal with the \`.open()\` method. Similarly, 
 const Template = ({
   triggerSlot,
   headerSlot,
+  accessibilityDescription,
   defaultSlot,
   size,
 }): TemplateResult => {
   return html`
     <outline-modal size="${ifDefined(size)}">
       ${ifDefined(triggerSlot)} ${ifDefined(headerSlot)}
-      ${ifDefined(defaultSlot)}
+      ${ifDefined(defaultSlot)} ${ifDefined(accessibilityDescription)}
     </outline-modal>
   `;
 };
@@ -110,6 +123,11 @@ Small.args = {
     <outline-heading slot="outline-modal--header">
       The modal header
     </outline-heading>
+  `,
+  accessibilityDescription: html`
+    <p slot="outline-modal--accessibility-description">
+      This is an accessibility description about the modal.
+    </p>
   `,
   defaultSlot: html`
     <p>Here is a first line of the modal.</p>
@@ -177,6 +195,23 @@ ButtonTrigger.args = {
     <outline-heading slot="outline-modal--header">
       The modal header
     </outline-heading>
+  `,
+  defaultSlot: html`
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+  `,
+};
+
+export const NoHeader = Template.bind({});
+NoHeader.args = {
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      <p>Open modal without header.</p>
+    </outline-link>
   `,
   defaultSlot: html`
     <p>Here is a first line of the modal.</p>

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -10,26 +10,22 @@ export default {
   argTypes: {
     triggerSlot: {
       name: 'slot="outline-modal--trigger"',
-      description: 'The trigger slot.',
-      // @todo how can we edit this as HTML.
-      control: { type: 'text' },
+      description: 'The trigger slot. For example, an "open modal" button.',
+      // We aren't setting a control type here so we can edit the value using the infered object.
     },
     headerSlot: {
       name: 'slot="outline-modal--header"',
-      description: 'The header slot.',
-      // @todo how can we edit this as HTML.
-      control: { type: 'text' },
+      description: 'The header slot. For example a header title.',
+      // We aren't setting a control type here so we can edit the value using the infered object.
     },
     // This is the modal content.
-    defaultSlot: {
-      ...argTypeSlotContent.defaultSlot,
-      // @todo how can we edit this as HTML.
-      control: { type: 'text' },
-    },
+    // We aren't setting a control type here so we can edit the value using the infered object.
+    ...argTypeSlotContent,
     size: {
       name: 'size',
       description: 'The size of the modal.',
       options: modalSizes,
+      control: { type: 'select' },
     },
   },
 };
@@ -42,33 +38,69 @@ const Template = ({
 }): TemplateResult => {
   return html`
     <outline-modal size="${ifDefined(size)}">
-      <div slot="outline-modal--trigger">${triggerSlot}</div>
-      <div slot="outline-modal--header">${headerSlot}</div>
-      ${defaultSlot}
+      ${ifDefined(triggerSlot)} ${ifDefined(headerSlot)}
+      ${ifDefined(defaultSlot)}
     </outline-modal>
   `;
 };
 
 export const Small = Template.bind({});
 Small.args = {
-  triggerSlot: html`<a href="#">Open modal</a>`,
-  headerSlot: html`<h2>The modal header</h2>`,
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      Open small modal
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
   defaultSlot: html`<p>A small modal.</p>`,
   size: 'small',
 };
 
 export const Medium = Template.bind({});
 Medium.args = {
-  triggerSlot: html`<a href="#">Open modal</a>`,
-  headerSlot: html`<h2>The modal header</h2>`,
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      Open medium modal
+    </outline-link>
+  `,
+  headerSlot: html` <outline-heading slot="outline-modal--header">
+    The modal header
+  </outline-heading>`,
   defaultSlot: html`<p>A medium modal.</p>`,
   size: 'medium',
 };
 
 export const FullScreen = Template.bind({});
 FullScreen.args = {
-  triggerSlot: html`<a href="#">Open modal</a>`,
-  headerSlot: html`<h2>The modal header</h2>`,
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      Open full screen modal
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
   defaultSlot: html`<p>A full screen modal.</p>`,
   size: 'full-screen',
+};
+
+export const ButtonTrigger = Template.bind({});
+ButtonTrigger.args = {
+  triggerSlot: html`
+    <outline-button slot="outline-modal--trigger">
+      Open modal with button trigger
+    </outline-button>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
+  defaultSlot: html`<p>A small modal.</p>`,
 };

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -72,7 +72,29 @@ You could make a button within the modal to close it.
 Example:
 
 \`\`\`HTML
-<button class="accept" onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})">
+<button
+  class="accept"
+  onClick="
+    document.querySelectorAll('outline-modal').forEach(
+      (node) => {
+        if(node.isOpen){
+          node.close();
+        }
+      }
+    )
+  "
+  onkeydown="
+    if (event.key === 'Enter') {
+      document.querySelectorAll('outline-modal').forEach(
+        (node) => {
+          if(node.isOpen){
+            node.close();
+          }
+        }
+      )
+    }
+  "
+>Accept</button>
 \`\`\`
 
 ## Variations

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -46,6 +46,12 @@ export default {
       options: modalSizes,
       control: { type: 'select' },
     },
+    shouldForceAction: {
+      name: 'shouldForceAction',
+      description:
+        'Force the user to take an action by removing close features. The modal contents will need to provide a way to close the modal.',
+      control: { type: 'boolean' },
+    },
     elementToFocusSelector: {
       name: 'elementToFocusSelector',
       description:
@@ -101,6 +107,8 @@ Example:
 
 You can set the \`size\` to change the size of the modal.
 
+You can force the user to take an action by setting \`shouldForceAction\`. In this situation, the modal contents will need to provide a way to close the modal since the standard close features will not be provided.
+
 ## Accessibility
 
 Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html).
@@ -140,6 +148,7 @@ You can access the boolean \`isOpen\` property to determine if the modal is open
         code: `
 <outline-modal
   size="{{ size }}"
+  {{ shouldForceAction }}
   elementToFocusSelector="{{ elementToFocusSelector }}"
 >
   <outline-link slot="outline-modal--trigger">{{ triggerSlot}}</outline-link>
@@ -159,11 +168,13 @@ const Template = ({
   accessibilityDescription,
   defaultSlot,
   size,
+  shouldForceAction,
   elementToFocusSelector,
 }): TemplateResult => {
   return html`
     <outline-modal
       size="${ifDefined(size)}"
+      ?shouldForceAction="${shouldForceAction}"
       elementToFocusSelector="${ifDefined(elementToFocusSelector)}"
     >
       ${ifDefined(triggerSlot)} ${ifDefined(headerSlot)}
@@ -402,4 +413,53 @@ AutoFocusedElement.args = {
       Accept
     </button>
   `,
+};
+
+export const ForceAction = Template.bind({});
+ForceAction.args = {
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      <p>Open modal and force an action.</p>
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
+  defaultSlot: html`
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+    <button
+      class="accept"
+      onClick="
+        document.querySelectorAll('outline-modal').forEach(
+          (node) => {
+            if(node.isOpen){
+              node.close();
+            }
+          }
+        )
+      "
+      onkeydown="
+        if (event.key === 'Enter') {
+          document.querySelectorAll('outline-modal').forEach(
+            (node) => {
+              if(node.isOpen){
+                node.close();
+              }
+            }
+          )
+        }
+      "
+    >
+      Accept
+    </button>
+  `,
+  shouldForceAction: true,
+  elementToFocusSelector: '.accept',
 };

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -112,8 +112,12 @@ Small.args = {
     </outline-heading>
   `,
   defaultSlot: html`
-<p>Here is a first line of the modal.</p>
-<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
   `,
   size: 'small',
 };
@@ -129,9 +133,13 @@ Medium.args = {
     The modal header
   </outline-heading>`,
   defaultSlot: html`
-<p>Here is a first line of the modal.</p>
-<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
-    `,
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+  `,
   size: 'medium',
 };
 
@@ -148,9 +156,13 @@ FullScreen.args = {
     </outline-heading>
   `,
   defaultSlot: html`
-<p>Here is a first line of the modal.</p>
-<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
-    `,
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+  `,
   size: 'full-screen',
 };
 
@@ -167,7 +179,11 @@ ButtonTrigger.args = {
     </outline-heading>
   `,
   defaultSlot: html`
-<p>Here is a first line of the modal.</p>
-<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
-    `,
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+  `,
 };

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -103,7 +103,7 @@ export const Small = Template.bind({});
 Small.args = {
   triggerSlot: html`
     <outline-link slot="outline-modal--trigger">
-      Open small modal
+      <p>Open small modal.</p>
     </outline-link>
   `,
   headerSlot: html`
@@ -111,7 +111,10 @@ Small.args = {
       The modal header
     </outline-heading>
   `,
-  defaultSlot: html`<p>A small modal.</p>`,
+  defaultSlot: html`
+<p>Here is a first line of the modal.</p>
+<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
+  `,
   size: 'small',
 };
 
@@ -125,7 +128,10 @@ Medium.args = {
   headerSlot: html` <outline-heading slot="outline-modal--header">
     The modal header
   </outline-heading>`,
-  defaultSlot: html`<p>A medium modal.</p>`,
+  defaultSlot: html`
+<p>Here is a first line of the modal.</p>
+<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
+    `,
   size: 'medium',
 };
 
@@ -141,7 +147,10 @@ FullScreen.args = {
       The modal header
     </outline-heading>
   `,
-  defaultSlot: html`<p>A full screen modal.</p>`,
+  defaultSlot: html`
+<p>Here is a first line of the modal.</p>
+<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
+    `,
   size: 'full-screen',
 };
 
@@ -157,5 +166,8 @@ ButtonTrigger.args = {
       The modal header
     </outline-heading>
   `,
-  defaultSlot: html`<p>A small modal.</p>`,
+  defaultSlot: html`
+<p>Here is a first line of the modal.</p>
+<p>This has a longer line so we can test line breaks, etc. This is going to be another sentence so we can see a longer paragraph. How about this? Thanks.</p>
+    `,
 };

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -46,6 +46,12 @@ export default {
       options: modalSizes,
       control: { type: 'select' },
     },
+    elementToFocusSelector: {
+      name: 'elementToFocusSelector',
+      description:
+        'An element to focus on when the modal is opened. This might be a primary call to action such as "accept". If no value is provided, the modal will try to find the best thing to focus on. Should be a valid CSS selector.',
+      control: { type: 'text' },
+    },
   },
   parameters: {
     docs: {
@@ -58,6 +64,16 @@ This component renders a trigger and modal. When the trigger is active, the moda
 You can add a trigger slot to the modal \`slot="outline-modal--trigger"\`.
 
 You can also manually trigger the modal with the \`.open()\` method. Similarly, you can close the modal with \`.close()\`.
+
+## Triggering the modal close with Javascript
+
+You could make a button within the modal to close it.
+
+Example:
+
+\`\`\`HTML
+<button class="accept" onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})">
+\`\`\`
 
 ## Variations
 
@@ -73,9 +89,11 @@ Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example
 ### Optional features
 - If a header is supplied as a slot, it is referenced with \`aria-labelledby\`
 - If an accessibility description is supplied by a slot, it is referenced with \`aria-describedby\`
+- The system will try to focus the first focusable element. If you would like, you can provide a selector with the \`elementToFocusSelector\` attribute and this will be focused.
 
 ### Keyboard navigation
 - If a trigger is supplied as a slot, that element can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+- On open, the modal will focus on the first focusable element, or the modal wrapper if none can be focused.
 - The \`Escape\` button can be used to close the modal
 - The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
 - When the modal is closed, the trigger is focused.
@@ -114,9 +132,13 @@ const Template = ({
   accessibilityDescription,
   defaultSlot,
   size,
+  elementToFocusSelector,
 }): TemplateResult => {
   return html`
-    <outline-modal size="${ifDefined(size)}">
+    <outline-modal
+      size="${ifDefined(size)}"
+      elementToFocusSelector="${ifDefined(elementToFocusSelector)}"
+    >
       ${ifDefined(triggerSlot)} ${ifDefined(headerSlot)}
       ${ifDefined(defaultSlot)} ${ifDefined(accessibilityDescription)}
     </outline-modal>
@@ -231,5 +253,63 @@ NoHeader.args = {
       be another sentence so we can see a longer paragraph. How about this?
       Thanks.
     </p>
+  `,
+};
+
+// @todo I could not set focus on the `outline-button` element, but a standard `button` works.
+export const CustomFocusElement = Template.bind({});
+CustomFocusElement.args = {
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      <p>Open modal and focus on accept button.</p>
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
+  defaultSlot: html`
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+    <outline-button class="cancel">Cancel</outline-button>
+    <button
+      class="accept"
+      onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})"
+    >
+      Accept
+    </button>
+  `,
+  elementToFocusSelector: '.accept',
+};
+
+export const AutoFocusedElement = Template.bind({});
+AutoFocusedElement.args = {
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      <p>Open modal and focus on accept button automatically.</p>
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
+  defaultSlot: html`
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+    <button
+      onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})"
+    >
+      Accept
+    </button>
   `,
 };

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -41,6 +41,37 @@ export default {
   },
   parameters: {
     docs: {
+      description: {
+        component: `
+## Accessibility
+
+- If a trigger is supplied as a slot, that element can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+- The \`Escape\` button can be used to close the modal
+- The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+
+## Variations
+
+You can set the \`size\` to change the size of the modal.
+
+## Events
+
+Events are triggered by the modal.
+
+- \`opened\`
+- \`closed\`
+
+## Properties
+
+You can access the boolean \`isOpen\` property to determine if the modal is open.
+
+## Triggering the modal
+
+You can add a trigger slot to the modal \`slot="outline-modal--trigger"\`.
+
+You can also manually trigger the modal with the \`.open()\` method. Similarly, you can close the modal with \`.close()\`.
+
+`,
+      },
       source: {
         code: `
 <outline-modal size="{{ size }}">

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -307,7 +307,26 @@ CustomFocusElement.args = {
     <outline-button class="cancel">Cancel</outline-button>
     <button
       class="accept"
-      onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})"
+      onClick="
+        document.querySelectorAll('outline-modal').forEach(
+          (node) => {
+            if(node.isOpen){
+              node.close();
+            }
+          }
+        )
+      "
+      onkeyup="
+        if (event.key === 'Enter') {
+          document.querySelectorAll('outline-modal').forEach(
+            (node) => {
+              if(node.isOpen){
+                node.close();
+              }
+            }
+          )
+        }
+      "
     >
       Accept
     </button>
@@ -336,7 +355,26 @@ AutoFocusedElement.args = {
       Thanks.
     </p>
     <button
-      onClick="document.querySelectorAll('outline-modal').forEach((node) => {if(node.isOpen){node.close();}})"
+      onClick="
+        document.querySelectorAll('outline-modal').forEach(
+          (node) => {
+            if(node.isOpen){
+              node.close();
+            }
+          }
+        )
+      "
+      onkeyup="
+        if (event.key === 'Enter') {
+          document.querySelectorAll('outline-modal').forEach(
+            (node) => {
+              if(node.isOpen){
+                node.close();
+              }
+            }
+          )
+        }
+      "
     >
       Accept
     </button>

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -51,29 +51,7 @@ export default {
     docs: {
       description: {
         component: `
-## Accessibility
-
-Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html).
-
-- Modal uses full screen on small devices
-- If a trigger is supplied as a slot, that element can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
-- The \`Escape\` button can be used to close the modal
-- The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
-
-## Variations
-
-You can set the \`size\` to change the size of the modal.
-
-## Events
-
-Events are triggered by the modal.
-
-- \`opened\`
-- \`closed\`
-
-## Properties
-
-You can access the boolean \`isOpen\` property to determine if the modal is open.
+This component renders a trigger and modal. When the trigger is active, the modal opens.
 
 ## Triggering the modal
 
@@ -81,6 +59,39 @@ You can add a trigger slot to the modal \`slot="outline-modal--trigger"\`.
 
 You can also manually trigger the modal with the \`.open()\` method. Similarly, you can close the modal with \`.close()\`.
 
+## Variations
+
+You can set the \`size\` to change the size of the modal.
+
+## Accessibility
+
+Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html).
+
+### Accessible style
+- Modal uses full screen on small devices
+
+### Optional features
+- If a header is supplied as a slot, it is referenced with \`aria-labelledby\`
+- If an accessibility description is supplied by a slot, it is referenced with \`aria-describedby\`
+
+### Keyboard navigation
+- If a trigger is supplied as a slot, that element can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+- The \`Escape\` button can be used to close the modal
+- The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+- When the modal is closed, the trigger is focused.
+
+## Javascript interaction
+
+### Events
+
+Events are triggered by the modal.
+
+- \`opened\`
+- \`closed\`
+
+### Properties
+
+You can access the boolean \`isOpen\` property to determine if the modal is open.
 `,
       },
       source: {

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -96,6 +96,7 @@ Based on guidelines from [WAI-ARIA Authoring Practices 1.1: Modal Dialog Example
 - On open, the modal will focus on the first focusable element, or the modal wrapper if none can be focused.
 - The \`Escape\` button can be used to close the modal
 - The close button can be focused and triggered with the keyboard (\`Tab\` and \`Enter\`)
+- Focus in kept within the modal (\`Tab\`, \`Shift+Tab\`)
 - When the modal is closed, the trigger is focused.
 
 ## Javascript interaction
@@ -304,7 +305,7 @@ CustomFocusElement.args = {
       be another sentence so we can see a longer paragraph. How about this?
       Thanks.
     </p>
-    <outline-button class="cancel">Cancel</outline-button>
+    <button class="cancel">Cancel</button>
     <button
       class="accept"
       onClick="
@@ -316,7 +317,7 @@ CustomFocusElement.args = {
           }
         )
       "
-      onkeyup="
+      onkeydown="
         if (event.key === 'Enter') {
           document.querySelectorAll('outline-modal').forEach(
             (node) => {
@@ -364,7 +365,7 @@ AutoFocusedElement.args = {
           }
         )
       "
-      onkeyup="
+      onkeydown="
         if (event.key === 'Enter') {
           document.querySelectorAll('outline-modal').forEach(
             (node) => {

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -1,0 +1,74 @@
+import { html, TemplateResult } from 'lit';
+import './outline-modal';
+import { argTypeSlotContent } from '../../base/outline-element/utils/utils';
+import { modalSizes } from './outline-modal';
+import { ifDefined } from 'lit/directives/if-defined';
+
+export default {
+  title: 'Molecules/Modal',
+  component: 'outline-modal',
+  argTypes: {
+    triggerSlot: {
+      name: 'slot="outline-modal--trigger"',
+      description: 'The trigger slot.',
+      // @todo how can we edit this as HTML.
+      control: { type: 'text' },
+    },
+    headerSlot: {
+      name: 'slot="outline-modal--header"',
+      description: 'The header slot.',
+      // @todo how can we edit this as HTML.
+      control: { type: 'text' },
+    },
+    // This is the modal content.
+    defaultSlot: {
+      ...argTypeSlotContent.defaultSlot,
+      // @todo how can we edit this as HTML.
+      control: { type: 'text' },
+    },
+    size: {
+      name: 'size',
+      description: 'The size of the modal.',
+      options: modalSizes,
+    },
+  },
+};
+
+const Template = ({
+  triggerSlot,
+  headerSlot,
+  defaultSlot,
+  size,
+}): TemplateResult => {
+  return html`
+    <outline-modal size="${ifDefined(size)}">
+      <div slot="outline-modal--trigger">${triggerSlot}</div>
+      <div slot="outline-modal--header">${headerSlot}</div>
+      ${defaultSlot}
+    </outline-modal>
+  `;
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  triggerSlot: html`<a href="#">Open modal</a>`,
+  headerSlot: html`<h2>The modal header</h2>`,
+  defaultSlot: html`<p>A small modal.</p>`,
+  size: 'small',
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  triggerSlot: html`<a href="#">Open modal</a>`,
+  headerSlot: html`<h2>The modal header</h2>`,
+  defaultSlot: html`<p>A medium modal.</p>`,
+  size: 'medium',
+};
+
+export const FullScreen = Template.bind({});
+FullScreen.args = {
+  triggerSlot: html`<a href="#">Open modal</a>`,
+  headerSlot: html`<h2>The modal header</h2>`,
+  defaultSlot: html`<p>A full screen modal.</p>`,
+  size: 'full-screen',
+};

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -113,8 +113,12 @@ You can access the boolean \`isOpen\` property to determine if the modal is open
 `,
       },
       source: {
+        // This code sample will be used for every example unless overridden.
         code: `
-<outline-modal size="{{ size }}">
+<outline-modal
+  size="{{ size }}"
+  elementToFocusSelector="{{ elementToFocusSelector }}"
+>
   <outline-link slot="outline-modal--trigger">{{ triggerSlot}}</outline-link>
   <outline-heading slot="outline-modal--header">{{ headerSlot}}</outline-heading>
   <p slot="outline-modal--accessibility-description">{{ accessibilityDescription }}</p>
@@ -156,11 +160,6 @@ Small.args = {
     <outline-heading slot="outline-modal--header">
       The modal header
     </outline-heading>
-  `,
-  accessibilityDescription: html`
-    <p slot="outline-modal--accessibility-description">
-      This is an accessibility description about the modal.
-    </p>
   `,
   defaultSlot: html`
     <p>Here is a first line of the modal.</p>
@@ -256,6 +255,35 @@ NoHeader.args = {
   `,
 };
 
+// This demonstrates an accessibility feature.
+export const AccessibilityDescription = Template.bind({});
+AccessibilityDescription.args = {
+  triggerSlot: html`
+    <outline-link slot="outline-modal--trigger">
+      <p>Open a modal with an accessibility description.</p>
+    </outline-link>
+  `,
+  headerSlot: html`
+    <outline-heading slot="outline-modal--header">
+      The modal header
+    </outline-heading>
+  `,
+  accessibilityDescription: html`
+    <p slot="outline-modal--accessibility-description">
+      This is an accessibility description about the modal.
+    </p>
+  `,
+  defaultSlot: html`
+    <p>Here is a first line of the modal.</p>
+    <p>
+      This has a longer line so we can test line breaks, etc. This is going to
+      be another sentence so we can see a longer paragraph. How about this?
+      Thanks.
+    </p>
+  `,
+};
+
+// This demonstrates an accessibility feature.
 // @todo I could not set focus on the `outline-button` element, but a standard `button` works.
 export const CustomFocusElement = Template.bind({});
 CustomFocusElement.args = {
@@ -287,6 +315,7 @@ CustomFocusElement.args = {
   elementToFocusSelector: '.accept',
 };
 
+// This demonstrates an accessibility feature.
 export const AutoFocusedElement = Template.bind({});
 AutoFocusedElement.args = {
   triggerSlot: html`

--- a/src/components/base/outline-modal/outline-modal.stories.ts
+++ b/src/components/base/outline-modal/outline-modal.stories.ts
@@ -11,21 +11,45 @@ export default {
     triggerSlot: {
       name: 'slot="outline-modal--trigger"',
       description: 'The trigger slot. For example, an "open modal" button.',
+      table: {
+        category: 'Slots',
+      },
       // We aren't setting a control type here so we can edit the value using the infered object.
     },
     headerSlot: {
       name: 'slot="outline-modal--header"',
       description: 'The header slot. For example a header title.',
+      table: {
+        category: 'Slots',
+      },
       // We aren't setting a control type here so we can edit the value using the infered object.
     },
     // This is the modal content.
     // We aren't setting a control type here so we can edit the value using the infered object.
-    ...argTypeSlotContent,
+    defaultSlot: {
+      ...argTypeSlotContent.defaultSlot,
+      table: {
+        category: 'Slots',
+      },
+    },
     size: {
       name: 'size',
       description: 'The size of the modal.',
       options: modalSizes,
       control: { type: 'select' },
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<outline-modal size="{{ size }}">
+  <outline-link slot="outline-modal--trigger">{{ triggerSlot}}</outline-link>
+  <outline-heading slot="outline-modal--header">{{ headerSlot}}</outline-heading>
+  {{ defaultSlot }}
+</outline-modal>
+        `,
+      },
     },
   },
 };

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -2,11 +2,19 @@ import { html, TemplateResult, CSSResultGroup } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
-import { ifDefined } from 'lit/directives/if-defined';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 export type ModalSize = 'small' | 'medium' | 'full-screen';
 
 export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
+
+// This is helpful in testing.
+export interface OutlineModalInterface extends HTMLElement {
+  isOpen: Boolean;
+  size?: ModalSize;
+  open: () => void;
+  close: () => void;
+}
 
 // See https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus.
 // @todo make this re-usable across components?
@@ -31,8 +39,17 @@ const focusableElementSelector = `
  * @slot outline-modal--accessibility-description - The accessibility description which is used by screen readers.
  */
 @customElement('outline-modal')
-export class OutlineModal extends OutlineElement {
+export class OutlineModal
+  extends OutlineElement
+  implements OutlineModalInterface
+{
   static styles: CSSResultGroup = [componentStyles];
+
+  @property({ attribute: false })
+  isOpen = false;
+
+  @property({ type: String })
+  size?: ModalSize = 'medium';
 
   render(): TemplateResult {
     return html`
@@ -47,12 +64,6 @@ export class OutlineModal extends OutlineElement {
       ${this._overlayTemplate()}
     `;
   }
-
-  @property({ attribute: false })
-  isOpen = false;
-
-  @property({ type: String })
-  size?: ModalSize = 'medium';
 
   @state()
   _hasHeaderSlot: boolean;

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -4,9 +4,8 @@ import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-export type ModalSize = 'small' | 'medium' | 'full-screen';
-
-export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
+export const modalSizes = ['small', 'medium', 'full-screen'] as const;
+export type ModalSize = typeof modalSizes[number];
 
 // This is helpful in testing.
 export interface OutlineModalInterface extends HTMLElement {

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -173,29 +173,23 @@ export class OutlineModal extends OutlineElement {
   elementToFocusSelector?: string | undefined;
 
   private _focusOnElement(): void {
-    let elementToFocus: HTMLElement = this.closeElement;
+    const defaultElement: HTMLElement = this.closeElement;
 
-    if (this.elementToFocusSelector !== undefined) {
-      const attributeDefinedElementToFocus = this.querySelector(
-        this.elementToFocusSelector
-      ) as HTMLElement | null;
+    const attributeDefinedElement =
+      this.elementToFocusSelector !== undefined
+        ? (this.querySelector(
+            this.elementToFocusSelector
+          ) as HTMLElement | null)
+        : null;
 
-      if (attributeDefinedElementToFocus !== null) {
-        elementToFocus = attributeDefinedElementToFocus;
-      }
-    }
+    const automaticallySelectedElement = this.querySelector(
+      focusableElementSelector
+    ) as HTMLElement | null;
 
-    if (this.elementToFocusSelector === undefined) {
-      const automaticallySelectedElementToFocus = this.querySelector(
-        focusableElementSelector
-      ) as HTMLElement | null;
+    const element =
+      attributeDefinedElement ?? automaticallySelectedElement ?? defaultElement;
 
-      if (automaticallySelectedElementToFocus !== null) {
-        elementToFocus = automaticallySelectedElementToFocus;
-      }
-    }
-
-    elementToFocus.focus();
+    element.focus();
   }
 
   private _trapFocus(): void {

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -195,12 +195,8 @@ export class OutlineModal extends OutlineElement {
   private _trapFocus(): void {
     const firstFocusableElement = this.closeElement;
 
-    const focusableSlottedElements: NodeListOf<HTMLElement> =
-      this.querySelectorAll(focusableElementSelector);
-
     const lastFocusableElement =
-      focusableSlottedElements[focusableSlottedElements.length - 1] ??
-      firstFocusableElement;
+      this.lastFocusableSlottedElement ?? firstFocusableElement;
 
     lastFocusableElement.addEventListener('keydown', event => {
       if (event.key === 'Tab' && event.shiftKey === false) {
@@ -217,5 +213,14 @@ export class OutlineModal extends OutlineElement {
         lastFocusableElement.focus();
       }
     });
+  }
+
+  private get lastFocusableSlottedElement(): HTMLElement | null {
+    const focusableSlottedElements: NodeListOf<HTMLElement> =
+      this.querySelectorAll(focusableElementSelector);
+
+    return (
+      focusableSlottedElements[focusableSlottedElements.length - 1] ?? null
+    );
   }
 }

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 
@@ -17,19 +17,44 @@ export class OutlineModal extends OutlineElement {
   /**
    * The size of the modal.
    */
-  @property({ type: String }) size?: ModalSize = 'medium';
+  @property({ type: String })
+  size?: ModalSize = 'medium';
+
+  @state()
+  _isOpen = false;
+
+  private _handleModalTrigger(): void {
+    this._isOpen = true;
+  }
+
+  private _handleModalClose(): void {
+    this._isOpen = false;
+  }
+
+  private _overlayTemplate(): TemplateResult {
+    let template = html``;
+
+    if (this._isOpen) {
+      template = html`
+        <div id="overlay" class="${this.size}">
+          <div id="close" @click="${this._handleModalClose}">Close</div>
+          <div id="header">
+            <slot name="outline-modal--header"></slot>
+          </div>
+          <slot></slot>
+        </div>
+      `;
+    }
+
+    return template;
+  }
 
   render(): TemplateResult {
     return html`
-      <div id="trigger">
+      <div id="trigger" @click="${this._handleModalTrigger}">
         <slot name="outline-modal--trigger"></slot>
       </div>
-      <div id="overlay" class="${this.size}">
-        <div id="header">
-          <slot name="outline-modal--header"></slot>
-        </div>
-        <slot></slot>
-      </div>
+      ${this._overlayTemplate()}
     `;
   }
 }

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -29,6 +29,9 @@ export class OutlineModal extends OutlineElement {
   @query('#overlay')
   private overlayElement!: HTMLDivElement;
 
+  @query('#trigger')
+  private triggerElement!: HTMLDivElement;
+
   async open(): Promise<void> {
     if (!this.isOpen) {
       this.isOpen = true;
@@ -48,6 +51,8 @@ export class OutlineModal extends OutlineElement {
       await this.updateComplete;
 
       this.dispatchEvent(new CustomEvent('closed'));
+
+      this.triggerElement.focus();
     }
   }
 

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 
@@ -23,11 +23,16 @@ export class OutlineModal extends OutlineElement {
   @property({ attribute: false })
   isOpen = false;
 
+  @query('#overlay')
+  private overlayElement!: HTMLDivElement;
+
   async open(): Promise<void> {
     if (!this.isOpen) {
       this.isOpen = true;
 
       await this.updateComplete;
+
+      this.overlayElement.focus();
 
       this.dispatchEvent(new CustomEvent('opened'));
     }
@@ -69,6 +74,12 @@ export class OutlineModal extends OutlineElement {
     }
   }
 
+  private _handleOverlayKeyup(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
   private _overlayTemplate(): TemplateResult {
     let template = html``;
 
@@ -79,6 +90,7 @@ export class OutlineModal extends OutlineElement {
           tabindex="-1"
           class="${this.size}"
           @click="${this._handleModalClose}"
+          @keyup="${this._handleOverlayKeyup}"
         >
           <div
             id="container"

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -1,0 +1,35 @@
+import { html, TemplateResult, CSSResultGroup } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import componentStyles from './outline-modal.css.lit';
+import { OutlineElement } from '../outline-element/outline-element';
+
+export type ModalSize = 'small' | 'medium' | 'full-screen';
+
+export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
+
+/**
+ * The Outline Modal component
+ */
+@customElement('outline-modal')
+export class OutlineModal extends OutlineElement {
+  static styles: CSSResultGroup = [componentStyles];
+
+  /**
+   * The size of the modal.
+   */
+  @property({ type: String }) size: ModalSize;
+
+  render(): TemplateResult {
+    return html`
+      <div id="trigger">
+        <slot name="outline-modal--trigger"></slot>
+      </div>
+      <div id="overlay" class="${this.size}">
+        <div id="header">
+          <slot name="outline-modal--header"></slot>
+        </div>
+        <slot></slot>
+      </div>
+    `;
+  }
+}

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -67,6 +67,7 @@ export class OutlineModal extends OutlineElement {
                 id="close"
                 aria-label="Close modal"
                 @click="${this._handleModalClose}"
+                @keyup="${this._handleModalCloseKeyup}"
               ></button>
             </div>
             <div id="main">
@@ -171,6 +172,13 @@ export class OutlineModal extends OutlineElement {
 
   private _handleOverlayKeyup(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  // For some reason on the `Docs` tab of Storybook, the `click` event for the close button doesn't work with the `Enter` key without also watching the `keyup` event. This isn't the case on the `Canvas` tab.
+  private _handleModalCloseKeyup(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
       this.close();
     }
   }

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -2,6 +2,7 @@ import { html, TemplateResult, CSSResultGroup } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
+import { ifDefined } from 'lit/directives/if-defined';
 
 export type ModalSize = 'small' | 'medium' | 'full-screen';
 
@@ -13,6 +14,7 @@ export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
  * @slot default - The modal contents
  * @slot outline-modal--trigger - The trigger for the modal
  * @slot outline-modal--header - The header in the modal
+ * @slot outline-modal--accessibility-description - The accessibility description which is used by screen readers.
  */
 @customElement('outline-modal')
 export class OutlineModal extends OutlineElement {
@@ -81,6 +83,35 @@ export class OutlineModal extends OutlineElement {
     }
   }
 
+  private _getHeaderTitleSlotId(): string | null {
+    let id = null;
+
+    // When this was a class property, it wasn't finding the slot as expected.
+    const headerSlot: HTMLSlotElement | null = this.querySelector(
+      '[slot="outline-modal--header"]'
+    );
+
+    if (headerSlot !== null) {
+      id = 'header';
+    }
+
+    return id;
+  }
+
+  private _getAccessibilityDescriptionId(): string | null {
+    let id = null;
+
+    // When this was a class property, it wasn't finding the slot as expected.
+    const accessibilityDescriptionSlot: HTMLSlotElement | null =
+      this.querySelector('[slot="outline-modal--accessibility-description"]');
+
+    if (accessibilityDescriptionSlot !== null) {
+      id = 'accessibility-description';
+    }
+
+    return id;
+  }
+
   private _overlayTemplate(): TemplateResult {
     let template = html``;
 
@@ -97,7 +128,10 @@ export class OutlineModal extends OutlineElement {
             id="container"
             role="dialog"
             aria-modal="true"
-            aria-labelledby="header"
+            aria-labelledby="${ifDefined(this._getHeaderTitleSlotId())}"
+            aria-describedby="${ifDefined(
+              this._getAccessibilityDescriptionId()
+            )}"
           >
             <div id="header">
               <slot id="title" name="outline-modal--header"></slot>
@@ -112,6 +146,10 @@ export class OutlineModal extends OutlineElement {
             </div>
           </div>
         </div>
+        <slot
+          id="accessibility-description"
+          name="outline-modal--accessibility-description"
+        ></slot>
       `;
     }
 

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -20,143 +20,25 @@ export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
 export class OutlineModal extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
-  @property({ type: String })
-  size?: ModalSize = 'medium';
+  render(): TemplateResult {
+    return html`
+      <div
+        id="trigger"
+        tabindex="0"
+        @click="${this._handleModalTrigger}"
+        @keydown="${this._handleModalTrigger}"
+      >
+        <slot name="outline-modal--trigger"></slot>
+      </div>
+      ${this._overlayTemplate()}
+    `;
+  }
 
   @property({ attribute: false })
   isOpen = false;
 
   @property({ type: String })
-  elementToFocusSelector?: string | undefined;
-
-  @query('#overlay')
-  private overlayElement!: HTMLDivElement;
-
-  @query('#trigger')
-  private triggerElement!: HTMLDivElement;
-
-  async open(): Promise<void> {
-    if (!this.isOpen) {
-      this.isOpen = true;
-
-      await this.updateComplete;
-
-      this._focusOnModalElement();
-
-      this.dispatchEvent(new CustomEvent('opened'));
-    }
-  }
-
-  async close(): Promise<void> {
-    if (this.isOpen) {
-      this.isOpen = false;
-
-      await this.updateComplete;
-
-      this.dispatchEvent(new CustomEvent('closed'));
-
-      this.triggerElement.focus();
-    }
-  }
-
-  private _focusOnModalElement(): void {
-    let elementToFocus: HTMLElement = this.overlayElement;
-
-    if (this.elementToFocusSelector !== undefined) {
-      const attributeDefinedElementToFocus = this.querySelector(
-        this.elementToFocusSelector
-      ) as HTMLElement | null;
-
-      if (attributeDefinedElementToFocus !== null) {
-        elementToFocus = attributeDefinedElementToFocus;
-      }
-    }
-
-    if (this.elementToFocusSelector === undefined) {
-      // See https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus.
-      const automaticallySelectedElementToFocus = this.querySelector(`
-        a[href]:not([tabindex="-1"]),
-        area[href]:not([tabindex="-1"]),
-        input:not([disabled]):not([tabindex="-1"]),
-        select:not([disabled]):not([tabindex="-1"]),
-        textarea:not([disabled]):not([tabindex="-1"]),
-        button:not([disabled]):not([tabindex="-1"]),
-        iframe:not([tabindex="-1"]),
-        [tabindex]:not([tabindex="-1"]),
-        [contentEditable=true]:not([tabindex="-1"])
-      `) as HTMLElement | null;
-
-      if (automaticallySelectedElementToFocus !== null) {
-        elementToFocus = automaticallySelectedElementToFocus;
-      }
-    }
-
-    elementToFocus.focus();
-  }
-
-  private _handleModalTrigger(event: MouseEvent | KeyboardEvent): void {
-    let shouldOpen = false;
-
-    switch (event.type) {
-      case 'click':
-        shouldOpen = true;
-        break;
-      case 'keydown':
-        if ('key' in event && event.key === 'Enter') {
-          shouldOpen = true;
-          // This prevents a focused element from also triggering.
-          // For example, the modal opens and the "accept" button is focused and then triggered and the modal closes.
-          event.preventDefault();
-          break;
-        }
-    }
-
-    if (shouldOpen) {
-      this.open();
-    }
-  }
-
-  private _handleModalClose(event: Event): void {
-    // Only trigger if we click directly on the event that wants to receive the click.
-    if (event.target === event.currentTarget) {
-      this.close();
-    }
-  }
-
-  private _handleOverlayKeyup(event: KeyboardEvent): void {
-    if (event.key === 'Escape') {
-      this.close();
-    }
-  }
-
-  private _getHeaderTitleSlotId(): string | null {
-    let id = null;
-
-    // When this was a class property, it wasn't finding the slot as expected.
-    const headerSlot: HTMLSlotElement | null = this.querySelector(
-      '[slot="outline-modal--header"]'
-    );
-
-    if (headerSlot !== null) {
-      id = 'header';
-    }
-
-    return id;
-  }
-
-  private _getAccessibilityDescriptionId(): string | null {
-    let id = null;
-
-    // When this was a class property, it wasn't finding the slot as expected.
-    const accessibilityDescriptionSlot: HTMLSlotElement | null =
-      this.querySelector('[slot="outline-modal--accessibility-description"]');
-
-    if (accessibilityDescriptionSlot !== null) {
-      id = 'accessibility-description';
-    }
-
-    return id;
-  }
+  size?: ModalSize = 'medium';
 
   private _overlayTemplate(): TemplateResult {
     let template = html``;
@@ -202,17 +84,135 @@ export class OutlineModal extends OutlineElement {
     return template;
   }
 
-  render(): TemplateResult {
-    return html`
-      <div
-        id="trigger"
-        tabindex="0"
-        @click="${this._handleModalTrigger}"
-        @keydown="${this._handleModalTrigger}"
-      >
-        <slot name="outline-modal--trigger"></slot>
-      </div>
-      ${this._overlayTemplate()}
-    `;
+  private _getHeaderTitleSlotId(): string | null {
+    let id = null;
+
+    // When this was a class property, it wasn't finding the slot as expected.
+    const headerSlot: HTMLSlotElement | null = this.querySelector(
+      '[slot="outline-modal--header"]'
+    );
+
+    if (headerSlot !== null) {
+      id = 'header';
+    }
+
+    return id;
+  }
+
+  private _getAccessibilityDescriptionId(): string | null {
+    let id = null;
+
+    // When this was a class property, it wasn't finding the slot as expected.
+    const accessibilityDescriptionSlot: HTMLSlotElement | null =
+      this.querySelector('[slot="outline-modal--accessibility-description"]');
+
+    if (accessibilityDescriptionSlot !== null) {
+      id = 'accessibility-description';
+    }
+
+    return id;
+  }
+
+  async open(): Promise<void> {
+    if (!this.isOpen) {
+      this.isOpen = true;
+
+      await this.updateComplete;
+
+      this._focusOnModalElement();
+
+      this.dispatchEvent(new CustomEvent('opened'));
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.isOpen) {
+      this.isOpen = false;
+
+      await this.updateComplete;
+
+      this.dispatchEvent(new CustomEvent('closed'));
+
+      this.triggerElement.focus();
+    }
+  }
+
+  @query('#trigger')
+  private triggerElement!: HTMLDivElement;
+
+  private _handleModalTrigger(event: MouseEvent | KeyboardEvent): void {
+    let shouldOpen = false;
+
+    switch (event.type) {
+      case 'click':
+        shouldOpen = true;
+        break;
+      case 'keydown':
+        if ('key' in event && event.key === 'Enter') {
+          shouldOpen = true;
+          // This prevents a focused element from also triggering.
+          // For example, the modal opens and the "accept" button is focused and then triggered and the modal closes.
+          event.preventDefault();
+          break;
+        }
+    }
+
+    if (shouldOpen) {
+      this.open();
+    }
+  }
+
+  private _handleModalClose(event: Event): void {
+    // Only trigger if we click directly on the event that wants to receive the click.
+    if (event.target === event.currentTarget) {
+      this.close();
+    }
+  }
+
+  private _handleOverlayKeyup(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  @query('#overlay')
+  private overlayElement!: HTMLDivElement;
+
+  @property({ type: String })
+  elementToFocusSelector?: string | undefined;
+
+  private _focusOnModalElement(): void {
+    let elementToFocus: HTMLElement = this.overlayElement;
+
+    if (this.elementToFocusSelector !== undefined) {
+      const attributeDefinedElementToFocus = this.querySelector(
+        this.elementToFocusSelector
+      ) as HTMLElement | null;
+
+      if (attributeDefinedElementToFocus !== null) {
+        elementToFocus = attributeDefinedElementToFocus;
+      }
+    }
+
+    if (this.elementToFocusSelector === undefined) {
+      // See https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus.
+      const automaticallySelectedElementToFocus = this.querySelector(`
+        a[href]:not([tabindex="-1"]),
+        area[href]:not([tabindex="-1"]),
+        input:not([disabled]):not([tabindex="-1"]),
+        select:not([disabled]):not([tabindex="-1"]),
+        textarea:not([disabled]):not([tabindex="-1"]),
+        button:not([disabled]):not([tabindex="-1"]),
+        iframe:not([tabindex="-1"]),
+        [tabindex]:not([tabindex="-1"]),
+        [contentEditable=true]:not([tabindex="-1"])
+      `) as HTMLElement | null;
+
+      if (automaticallySelectedElementToFocus !== null) {
+        elementToFocus = automaticallySelectedElementToFocus;
+      }
+    }
+
+    elementToFocus.focus();
   }
 }

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -70,9 +70,17 @@ export class OutlineModal extends OutlineElement {
             id="container"
             role="dialog"
             aria-modal="true"
-            aria-labelledby="${ifDefined(this._getHeaderTitleSlotId())}"
+            aria-labelledby="${ifDefined(
+              this.querySelector('[slot="outline-modal--header"]') !== null
+                ? 'header'
+                : undefined
+            )}"
             aria-describedby="${ifDefined(
-              this._getAccessibilityDescriptionId()
+              this.querySelector(
+                '[slot="outline-modal--accessibility-description"]'
+              ) !== null
+                ? 'accessibility-description'
+                : undefined
             )}"
           >
             <div id="header">
@@ -97,35 +105,6 @@ export class OutlineModal extends OutlineElement {
     }
 
     return template;
-  }
-
-  private _getHeaderTitleSlotId(): string | null {
-    let id = null;
-
-    // When this was a class property, it wasn't finding the slot as expected.
-    const headerSlot: HTMLSlotElement | null = this.querySelector(
-      '[slot="outline-modal--header"]'
-    );
-
-    if (headerSlot !== null) {
-      id = 'header';
-    }
-
-    return id;
-  }
-
-  private _getAccessibilityDescriptionId(): string | null {
-    let id = null;
-
-    // When this was a class property, it wasn't finding the slot as expected.
-    const accessibilityDescriptionSlot: HTMLSlotElement | null =
-      this.querySelector('[slot="outline-modal--accessibility-description"]');
-
-    if (accessibilityDescriptionSlot !== null) {
-      id = 'accessibility-description';
-    }
-
-    return id;
   }
 
   async open(): Promise<void> {

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -9,14 +9,15 @@ export const modalSizes: ModalSize[] = ['small', 'medium', 'full-screen'];
 
 /**
  * The Outline Modal component
+ * @element outline-modal
+ * @slot default - The modal contents
+ * @slot outline-modal--trigger - The trigger for the modal
+ * @slot outline-modal--header - The header in the modal
  */
 @customElement('outline-modal')
 export class OutlineModal extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
-  /**
-   * The size of the modal.
-   */
   @property({ type: String })
   size?: ModalSize = 'medium';
 

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 import { ifDefined } from 'lit/directives/if-defined';
@@ -54,6 +54,26 @@ export class OutlineModal extends OutlineElement {
   @property({ type: String })
   size?: ModalSize = 'medium';
 
+  @state()
+  _hasHeaderSlot: boolean;
+
+  @state()
+  _hasAccessibilityDescriptionSlot: boolean;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._handleSlotChange();
+  }
+
+  private _handleSlotChange(): void {
+    this._hasHeaderSlot =
+      this.querySelector('[slot="outline-modal--header"]') !== null;
+    this._hasAccessibilityDescriptionSlot =
+      this.querySelector(
+        '[slot="outline-modal--accessibility-description"]'
+      ) !== null;
+  }
+
   private _overlayTemplate(): TemplateResult {
     let template = html``;
 
@@ -71,20 +91,20 @@ export class OutlineModal extends OutlineElement {
             role="dialog"
             aria-modal="true"
             aria-labelledby="${ifDefined(
-              this.querySelector('[slot="outline-modal--header"]') !== null
-                ? 'header'
-                : undefined
+              this._hasHeaderSlot ? 'header' : undefined
             )}"
             aria-describedby="${ifDefined(
-              this.querySelector(
-                '[slot="outline-modal--accessibility-description"]'
-              ) !== null
+              this._hasAccessibilityDescriptionSlot
                 ? 'accessibility-description'
                 : undefined
             )}"
           >
             <div id="header">
-              <slot id="title" name="outline-modal--header"></slot>
+              <slot
+                id="title"
+                name="outline-modal--header"
+                @slotchange="${this._handleSlotChange}"
+              ></slot>
               <button
                 id="close"
                 aria-label="Close modal"
@@ -100,6 +120,7 @@ export class OutlineModal extends OutlineElement {
         <slot
           id="accessibility-description"
           name="outline-modal--accessibility-description"
+          @slotchange="${this._handleSlotChange}"
         ></slot>
       `;
     }

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -23,12 +23,30 @@ export class OutlineModal extends OutlineElement {
   @state()
   _isOpen = false;
 
-  private _handleModalTrigger(): void {
-    this._isOpen = true;
+  private _handleModalTrigger(event: MouseEvent | KeyboardEvent): void {
+    let shouldOpen = false;
+
+    switch (event.type) {
+      case 'click':
+        shouldOpen = true;
+        break;
+      case 'keyup':
+        if ('key' in event && event.key === 'Enter') {
+          shouldOpen = true;
+          break;
+        }
+    }
+
+    if (shouldOpen) {
+      this._isOpen = true;
+    }
   }
 
-  private _handleModalClose(): void {
-    this._isOpen = false;
+  private _handleModalClose(event: Event): void {
+    // Only trigger if we click directly on the event that wants to receive the click.
+    if (event.target === event.currentTarget) {
+      this._isOpen = false;
+    }
   }
 
   private _overlayTemplate(): TemplateResult {
@@ -36,12 +54,30 @@ export class OutlineModal extends OutlineElement {
 
     if (this._isOpen) {
       template = html`
-        <div id="overlay" class="${this.size}">
-          <div id="close" @click="${this._handleModalClose}">Close</div>
-          <div id="header">
-            <slot name="outline-modal--header"></slot>
+        <div
+          id="overlay"
+          tabindex="-1"
+          class="${this.size}"
+          @click="${this._handleModalClose}"
+        >
+          <div
+            id="container"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="header"
+          >
+            <div id="header">
+              <slot id="title" name="outline-modal--header"></slot>
+              <button
+                id="close"
+                aria-label="Close modal"
+                @click="${this._handleModalClose}"
+              ></button>
+            </div>
+            <div id="main">
+              <slot></slot>
+            </div>
           </div>
-          <slot></slot>
         </div>
       `;
     }
@@ -51,7 +87,12 @@ export class OutlineModal extends OutlineElement {
 
   render(): TemplateResult {
     return html`
-      <div id="trigger" @click="${this._handleModalTrigger}">
+      <div
+        id="trigger"
+        tabindex="0"
+        @click="${this._handleModalTrigger}"
+        @keyup="${this._handleModalTrigger}"
+      >
         <slot name="outline-modal--trigger"></slot>
       </div>
       ${this._overlayTemplate()}

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -39,8 +39,8 @@ export class OutlineModal extends OutlineElement {
       <div
         id="trigger"
         tabindex="0"
-        @click="${this._handleModalTrigger}"
-        @keydown="${this._handleModalTrigger}"
+        @click="${this._handleTriggerClick}"
+        @keydown="${this._handleTriggerKeydown}"
       >
         <slot name="outline-modal--trigger"></slot>
       </div>
@@ -63,8 +63,8 @@ export class OutlineModal extends OutlineElement {
           id="overlay"
           tabindex="-1"
           class="${this.size}"
-          @click="${this._handleModalClose}"
-          @keydown="${this._handleOverlayKeyup}"
+          @click="${this._handleOverlayClick}"
+          @keydown="${this._handleOverlayKeydown}"
         >
           <div
             id="container"
@@ -80,8 +80,8 @@ export class OutlineModal extends OutlineElement {
               <button
                 id="close"
                 aria-label="Close modal"
-                @click="${this._handleModalClose}"
-                @keydown="${this._handleModalCloseKeyup}"
+                @click="${this._handleCloseClick}"
+                @keydown="${this._handleCloseKeydown}"
               ></button>
             </div>
             <div id="main">
@@ -134,9 +134,9 @@ export class OutlineModal extends OutlineElement {
 
       await this.updateComplete;
 
-      this._focusOnModalElement();
+      this._focusOnElement();
 
-      this._trapFocusWithinModal();
+      this._trapFocus();
 
       this.dispatchEvent(new CustomEvent('opened'));
     }
@@ -157,43 +157,39 @@ export class OutlineModal extends OutlineElement {
   @query('#trigger')
   private triggerElement!: HTMLDivElement;
 
-  private _handleModalTrigger(event: MouseEvent | KeyboardEvent): void {
-    let shouldOpen = false;
+  private _handleTriggerClick(): void {
+    this.open();
+  }
 
-    switch (event.type) {
-      case 'click':
-        shouldOpen = true;
-        break;
-      case 'keydown':
-        if ('key' in event && event.key === 'Enter') {
-          shouldOpen = true;
-          // This prevents a focused element from also triggering.
-          // For example, the modal opens and the "accept" button is focused and then triggered and the modal closes.
-          event.preventDefault();
-          break;
-        }
-    }
+  private _handleTriggerKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      // This prevents a focused element from also triggering.
+      // For example, the modal opens and the "accept" button is focused and then triggered and the modal closes.
+      event.preventDefault();
 
-    if (shouldOpen) {
       this.open();
     }
   }
 
-  private _handleModalClose(event: Event): void {
+  private _handleOverlayClick(event: MouseEvent): void {
     // Only trigger if we click directly on the event that wants to receive the click.
     if (event.target === event.currentTarget) {
       this.close();
     }
   }
 
-  private _handleOverlayKeyup(event: KeyboardEvent): void {
+  private _handleOverlayKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       this.close();
     }
   }
 
+  private _handleCloseClick(): void {
+    this.close();
+  }
+
   // For some reason on the `Docs` tab of Storybook, the `click` event for the close button doesn't work with the `Enter` key without also watching the `keyup` event. This isn't the case on the `Canvas` tab.
-  private _handleModalCloseKeyup(event: KeyboardEvent): void {
+  private _handleCloseKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter') {
       this.close();
     }
@@ -205,7 +201,7 @@ export class OutlineModal extends OutlineElement {
   @property({ type: String })
   elementToFocusSelector?: string | undefined;
 
-  private _focusOnModalElement(): void {
+  private _focusOnElement(): void {
     let elementToFocus: HTMLElement = this.closeElement;
 
     if (this.elementToFocusSelector !== undefined) {
@@ -231,7 +227,7 @@ export class OutlineModal extends OutlineElement {
     elementToFocus.focus();
   }
 
-  private _trapFocusWithinModal(): void {
+  private _trapFocus(): void {
     // We will use the close button as the first focusable element.
 
     let lastFocusableElement: HTMLElement = this.closeElement;

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -39,7 +39,7 @@ export class OutlineModal extends OutlineElement {
       <div
         id="trigger"
         tabindex="0"
-        @click="${this._handleTriggerClick}"
+        @click="${this.open}"
         @keydown="${this._handleTriggerKeydown}"
       >
         <slot name="outline-modal--trigger"></slot>
@@ -80,7 +80,7 @@ export class OutlineModal extends OutlineElement {
               <button
                 id="close"
                 aria-label="Close modal"
-                @click="${this._handleCloseClick}"
+                @click="${this.close}"
                 @keydown="${this._handleCloseKeydown}"
               ></button>
             </div>
@@ -157,10 +157,6 @@ export class OutlineModal extends OutlineElement {
   @query('#trigger')
   private triggerElement!: HTMLDivElement;
 
-  private _handleTriggerClick(): void {
-    this.open();
-  }
-
   private _handleTriggerKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter') {
       // This prevents a focused element from also triggering.
@@ -182,10 +178,6 @@ export class OutlineModal extends OutlineElement {
     if (event.key === 'Escape') {
       this.close();
     }
-  }
-
-  private _handleCloseClick(): void {
-    this.close();
   }
 
   // For some reason on the `Docs` tab of Storybook, the `click` event for the close button doesn't work with the `Enter` key without also watching the `keyup` event. This isn't the case on the `Canvas` tab.

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -193,27 +193,24 @@ export class OutlineModal extends OutlineElement {
   }
 
   private _trapFocus(): void {
-    // We will use the close button as the first focusable element.
+    const firstFocusableElement = this.closeElement;
 
-    let lastFocusableElement: HTMLElement = this.closeElement;
+    const focusableSlottedElements: NodeListOf<HTMLElement> =
+      this.querySelectorAll(focusableElementSelector);
 
-    const focusableElements: NodeListOf<HTMLElement> = this.querySelectorAll(
-      focusableElementSelector
-    );
-
-    if (focusableElements.length > 0) {
-      lastFocusableElement = focusableElements[focusableElements.length - 1];
-    }
+    const lastFocusableElement =
+      focusableSlottedElements[focusableSlottedElements.length - 1] ??
+      firstFocusableElement;
 
     lastFocusableElement.addEventListener('keydown', event => {
       if (event.key === 'Tab' && event.shiftKey === false) {
         event.preventDefault();
 
-        this.closeElement.focus();
+        firstFocusableElement.focus();
       }
     });
 
-    this.closeElement.addEventListener('keydown', event => {
+    firstFocusableElement.addEventListener('keydown', event => {
       if (event.key === 'Tab' && event.shiftKey) {
         event.preventDefault();
 

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import componentStyles from './outline-modal.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 
@@ -20,8 +20,28 @@ export class OutlineModal extends OutlineElement {
   @property({ type: String })
   size?: ModalSize = 'medium';
 
-  @state()
-  _isOpen = false;
+  @property({ attribute: false })
+  isOpen = false;
+
+  async open(): Promise<void> {
+    if (!this.isOpen) {
+      this.isOpen = true;
+
+      await this.updateComplete;
+
+      this.dispatchEvent(new CustomEvent('opened'));
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.isOpen) {
+      this.isOpen = false;
+
+      await this.updateComplete;
+
+      this.dispatchEvent(new CustomEvent('closed'));
+    }
+  }
 
   private _handleModalTrigger(event: MouseEvent | KeyboardEvent): void {
     let shouldOpen = false;
@@ -38,21 +58,21 @@ export class OutlineModal extends OutlineElement {
     }
 
     if (shouldOpen) {
-      this._isOpen = true;
+      this.open();
     }
   }
 
   private _handleModalClose(event: Event): void {
     // Only trigger if we click directly on the event that wants to receive the click.
     if (event.target === event.currentTarget) {
-      this._isOpen = false;
+      this.close();
     }
   }
 
   private _overlayTemplate(): TemplateResult {
     let template = html``;
 
-    if (this._isOpen) {
+    if (this.isOpen) {
       template = html`
         <div
           id="overlay"

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -17,7 +17,7 @@ export class OutlineModal extends OutlineElement {
   /**
    * The size of the modal.
    */
-  @property({ type: String }) size: ModalSize;
+  @property({ type: String }) size?: ModalSize = 'medium';
 
   render(): TemplateResult {
     return html`

--- a/src/components/base/outline-modal/test/outline-modal.test.ts
+++ b/src/components/base/outline-modal/test/outline-modal.test.ts
@@ -1,0 +1,88 @@
+import { OutlineModal } from '../outline-modal';
+import { expect, waitUntil } from '@open-wc/testing';
+
+// We are using these generic names so we can hopefully generalize this process or at least make copy & paste easier.
+const componentElementName = 'outline-modal';
+
+describe(componentElementName, () => {
+  // We don't get base styles automatically. Is there a better way?
+  const addBaseStyles = () => {
+    const defaultCSS = document.createElement('link');
+    defaultCSS.setAttribute('rel', 'stylesheet');
+    defaultCSS.setAttribute('href', '/outline.theme.css');
+
+    document.head.append(defaultCSS);
+  };
+
+  before(() => {
+    addBaseStyles();
+  });
+
+  it('Make sure to load necessary component JS', () => {
+    // If we don't use the component at least once, its JS will never be loaded and the component won't render. :(
+    const componentElement = document.createElement(componentElementName);
+
+    expect(componentElement).is.instanceOf(OutlineModal);
+  });
+
+  it('Slot elements while interacting with the modal.', async () => {
+    const modalElement = document.createElement(
+      componentElementName
+    ) as OutlineModal;
+
+    /**
+     * <button slot="outline-modal--trigger">
+     *  Open small modal.
+     * </button>
+     */
+    const triggerElement = document.createElement('button');
+    triggerElement.setAttribute('slot', 'outline-modal--trigger');
+    triggerElement.innerText = 'Open small modal';
+    modalElement.append(triggerElement);
+
+    /**
+     * <h2 slot="outline-modal--header">Modal header text</h2>
+     */
+    const headerElement = document.createElement('h2');
+    headerElement.setAttribute('slot', 'outline-modal--header');
+    headerElement.innerText = 'Modal header text';
+    modalElement.append(headerElement);
+
+    /**
+     * <p>Test message</p>
+     */
+    const messageElement = document.createElement('p');
+    messageElement.innerText = 'Test message';
+    modalElement.append(messageElement);
+
+    document.body.append(modalElement);
+
+    await waitUntil(
+      () => triggerElement.assignedSlot !== null,
+      'Trigger is slotted'
+    );
+
+    expect(triggerElement.assignedSlot, 'Trigger is slotted.').is.not.null;
+
+    expect(headerElement.assignedSlot, 'Header is not yet slotted.').is.null;
+
+    expect(messageElement.assignedSlot, 'Message is not yet slotted.').is.null;
+
+    modalElement.open();
+
+    await waitUntil(() => modalElement.isOpen === true, 'Modal is open');
+
+    expect(headerElement.assignedSlot, 'Header is slotted.').is.not.null;
+
+    expect(messageElement.assignedSlot, 'Message is slotted.').is.not.null;
+
+    modalElement.close();
+
+    await waitUntil(() => modalElement.isOpen === false, 'Modal is closed');
+
+    expect(headerElement.assignedSlot, 'Header is no longer slotted.').is.null;
+
+    expect(messageElement.assignedSlot, 'Message is no longer slotted.').is
+      .null;
+  });
+});

--- a/src/components/base/outline-modal/test/outline-modal.test.ts
+++ b/src/components/base/outline-modal/test/outline-modal.test.ts
@@ -1,4 +1,4 @@
-import { OutlineModal } from '../outline-modal';
+import { OutlineModal as OutlineComponent } from '../outline-modal';
 import { expect, waitUntil } from '@open-wc/testing';
 
 // We are using these generic names so we can hopefully generalize this process or at least make copy & paste easier.
@@ -22,13 +22,13 @@ describe(componentElementName, () => {
     // If we don't use the component at least once, its JS will never be loaded and the component won't render. :(
     const componentElement = document.createElement(componentElementName);
 
-    expect(componentElement).is.instanceOf(OutlineModal);
+    expect(componentElement).is.instanceOf(OutlineComponent);
   });
 
   it('Slot elements while interacting with the modal.', async () => {
     const modalElement = document.createElement(
       componentElementName
-    ) as OutlineModal;
+    ) as OutlineComponent;
 
     /**
      * <button slot="outline-modal--trigger">


### PR DESCRIPTION
# Description

Adds a modal. See #45 

# Testing notes
- Visit http://localhost:6006/?path=/story/molecules-modal--small and similar examples.

# Example

![modal_canvas](https://user-images.githubusercontent.com/397902/125838470-3af59c37-6506-4501-bb28-6b8a0bac365f.jpg)

## Documentation

![modal_documentation](https://user-images.githubusercontent.com/397902/125838376-f882a503-bbda-4456-9caa-2e6c19bab94c.jpg)

# Notes

Took concepts from https://micromodal.vercel.app and https://patternflyelements.org/components/modal

The controls for slots in Storybook are weird and this documentation works, but is awkward. Open to suggestions!


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/49"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

