### PR TITLE
docs: outline-button storybook help.

### DIFF
--- a/src/components/base/outline-button/outline-button.stories.ts
+++ b/src/components/base/outline-button/outline-button.stories.ts
@@ -45,6 +45,32 @@ export default {
   args: {
     variant: 'primary',
   },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This component renders a button that can either be a link or trigger an action.
+
+## Difference from \`button\` element
+
+This is rendered as an \`a\` element if a link and a \`button\` element if not a link. This allows for consistent styling that matches the user expectation of a button while matching the browser expectation for those elements.
+        `,
+      },
+      source: {
+        code: `
+<outline-button
+  url="{{ url }}"
+  target="{{ target }}"
+  variant="{{ variant }}"
+  disabled="{{ disabled }}"
+  icon="{{ icon }}"
+>
+  {{ defaultSlot }}
+</outline-button>
+        `,
+      },
+    },
+  },
 };
 
 const Template = ({


### PR DESCRIPTION
Add documentation around the `outline-button` component to try to give an idea of how it is used.

- sample markup
- description

## Testing
- Visit https://github.com/phase2/outline/compare/feature/doc/button?expand=1

## Example

![button-docs](https://user-images.githubusercontent.com/397902/125639824-54d8ceaf-d282-4a31-a8a6-c5fe28d49db7.jpg)

### Before

![before](https://user-images.githubusercontent.com/397902/125640230-b9518a2e-85e1-4c84-a3f4-ff4f66894d83.jpg)
