### PR TITLE
docs: outline-icon storybook help.

### DIFF
--- a/src/components/base/outline-element/utils/utils.ts
+++ b/src/components/base/outline-element/utils/utils.ts
@@ -86,6 +86,7 @@ export const argTypeSize = {
 
 export const argTypeColor = {
   name: 'Color',
+  description: 'Select from a pre-defined list of colors.',
   control: {
     type: 'select',
     options: ALL_COLORS,

--- a/src/components/base/outline-icon/outline-icon.stories.ts
+++ b/src/components/base/outline-icon/outline-icon.stories.ts
@@ -17,20 +17,60 @@ export default {
   argTypes: {
     color: argTypeColor,
     icon: {
+      description: 'Select from a pre-defined list of icons.',
       control: {
         type: 'select',
         options: IconList,
       },
     },
     variant: {
+      description: 'Is the icon solid or does it use an outline.',
       control: {
         type: 'select',
         options: IconVariant,
       },
     },
     url: {
+      description: 'Specify your own source URL for an icon.',
       control: {
         type: 'text',
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This component renders an icon as an \`img\` element.
+
+## Choosing the icon to render
+
+### Choosing a pre-defined icon
+
+You can select from a predefined \`icon\`.
+
+_@todo add documentation about \`variant\` and \`color\` when those are implemented._
+
+### Specifying your own source URL
+
+If you specify a \`url\`, this will be used.
+
+## Differences from an \`img\` element
+
+This component allows to vary the icon using attributes rather than selecting a new icon.
+
+_@todo specify why this would be used instead of an \`img\` element when the \`url\` pattern is used._
+
+        `,
+      },
+      source: {
+        code: `
+<outline-icon
+  icon="{{ icon }}"
+  url="{{ url }}"
+  color="{{ color }}"
+></outline-icon>
+        `,
       },
     },
   },


### PR DESCRIPTION
Add documentation around the `outline-icon` component to try to give an idea of how it is used.

- source example
- description of how the component is used
- general description for the color attribute

## Testing
- http://localhost:6006/?path=/docs/atoms-icon--select-icon

I added `@todo` notes about partially implemented features in this component.

## Example

![icon](https://user-images.githubusercontent.com/397902/125645381-3e699ace-0ade-459d-ba2a-0d56b475828c.jpg)

### Before

![before_icon](https://user-images.githubusercontent.com/397902/125645458-f31f71b9-5ca2-4569-aeda-b2188f95a876.jpg)
