### PR TITLE
docs: outline-image storybook help.

### DIFF
--- a/src/components/base/outline-image/outline-image.stories.ts
+++ b/src/components/base/outline-image/outline-image.stories.ts
@@ -10,6 +10,26 @@ export default {
   component: 'outline-image',
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+This component renders an image with an optional caption as a \`figure\` element and a \`figcaption\` element.
+
+## Difference between \`figure\` and \`figcaption\` element
+
+_@todo describe why this would be used instead._
+
+        `,
+      },
+      source: {
+        code: `
+<outline-image>
+  {{ defaultSlot }}
+  <outline-container slot="caption">{{ caption }}</outline-container>
+</outline-image>
+        `,
+      },
+    },
   },
   argTypes: {
     imageUrl: argTypeHidden,


### PR DESCRIPTION
Add documentation around the `outline-image` component to try to give an idea of how it is used.

- code sample
- description

## Testing
- http://localhost:6006/?path=/docs/atoms-image--static-image

Can someone fill in why this component is used in place of `figure` and `figcaption`?

## Example

![image_documentation](https://user-images.githubusercontent.com/397902/125647776-b3fadf68-842b-4169-a337-a31137af64d5.jpg)

### Before

![outline-before](https://user-images.githubusercontent.com/397902/125647844-a8c55cdd-992c-4983-9ef2-77e894c74888.jpg)
