### PR TITLE
docs: outline-link storybook help.

### DIFF
--- a/src/components/base/outline-link/outline-link.stories.ts
+++ b/src/components/base/outline-link/outline-link.stories.ts
@@ -33,6 +33,32 @@ export default {
     linkTarget: '_blank',
     linkText: 'Sample Link',
   },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This component renders a link as an \`a\` element.
+
+The default slot can be text or other elements such as images.
+
+## Difference from an \`a\` element.
+
+_@todo specify why this would be used instead of an \`a\` element._
+        `,
+      },
+      source: {
+        code: `
+<outline-link
+  linkHref="{{ linkHref }}"
+  linkRel="{{ linkRel }}"
+  linkTarget="{{ linkTarget }}"
+>
+  {{ defaultSlot }}
+</outline-link>
+        `,
+      },
+    },
+  },
 };
 
 interface Options {


### PR DESCRIPTION
Add documentation around the `outline-link` component to try to give an idea of how it is used.

- code sample
- description

## Testing
- http://localhost:6006/?path=/docs/atoms-link--link

Can someone describe why this would be used instead of an `a` element?

## Example

![link_docs](https://user-images.githubusercontent.com/397902/125650587-288ff5f4-6798-4651-aaf1-4be38dd0cf38.jpg)


### Before

![link_before](https://user-images.githubusercontent.com/397902/125650532-2abfecb2-8512-4641-86db-22a697e069b8.jpg)
