### PR TITLE
Feature: #41 Alert.

### DIFF
--- a/src/components/base/outline-alert/outline-alert.css
+++ b/src/components/base/outline-alert/outline-alert.css
@@ -6,7 +6,7 @@
 }
 
 #header {
-  @apply font-bold text-lg;
+  @apply font-bold text-lg capitalize;
 }
 
 :host([statusType='warning']) #body {

--- a/src/components/base/outline-alert/outline-alert.css
+++ b/src/components/base/outline-alert/outline-alert.css
@@ -1,0 +1,28 @@
+/* The default is information. */
+#body {
+  @apply block border-solid border-0 border-l-8 p-4 bg-ui-info text-ui-infoText;
+
+  border-color: var(--ui-infoText);
+}
+
+#header {
+  @apply font-bold text-lg;
+}
+
+:host([statusType='warning']) #body {
+  @apply bg-ui-warning text-ui-warningText;
+
+  border-color: var(--ui-warningText);
+}
+
+:host([statusType='error']) #body {
+  @apply bg-ui-error text-ui-errorText;
+
+  border-color: var(--ui-errorText);
+}
+
+:host([statusType='success']) #body {
+  @apply bg-ui-success text-ui-successText;
+
+  border-color: var(--ui-successText);
+}

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -38,6 +38,10 @@ export default {
       description: '(not yet implemented) Should we show the icon',
       control: { type: 'boolean' },
     },
+    isInteractive: {
+      description: 'Is there an interaction in the alert, such as a button.',
+      control: { type: 'boolean' },
+    },
   },
   parameters: {
     docs: {
@@ -52,6 +56,10 @@ You can set the type of alert with \`statusType\`.
 You can use a smaller alert with \`size\` of \`small\`.
 
 You can remove the icon with \`shouldShowIcon\` set to \`false\`.
+
+## Accessibility
+
+If the alert has an interaction, you should indicate this with \`isInteractive\` set to \`true\`.
 `,
       },
       source: {
@@ -61,6 +69,7 @@ You can remove the icon with \`shouldShowIcon\` set to \`false\`.
   statusType="{{ statusType }}"
   size="{{ size }}"
   shouldShowIcon="{{ shouldShowIcon }}"
+  isInteractive="{{ isInteractive }}"
 >
   <span slot="outline-alert--header">{{ headerSlot }}</span>
   {{ defaultSlot }}
@@ -77,12 +86,14 @@ const Template = ({
   statusType,
   size,
   shouldShowIcon,
+  isInteractive,
 }): TemplateResult => {
   return html`
     <outline-alert
       statusType="${ifDefined(statusType)}"
       size="${ifDefined(size)}"
       shouldShowIcon="${ifDefined(shouldShowIcon)}"
+      isInteractive="${ifDefined(isInteractive)}"
     >
       ${ifDefined(headerSlot)} ${ifDefined(defaultSlot)}
     </outline-alert>
@@ -135,10 +146,11 @@ NoIcon.args = {
   shouldShowIcon: false,
 };
 
-export const MessageWithLink = Template.bind({});
-MessageWithLink.args = {
+export const InteractiveAlert = Template.bind({});
+InteractiveAlert.args = {
   defaultSlot: html`
-    Here is an alert with a link.
+    Here is an alert with an interaction.
     <outline-link linkhref="#">Click here</outline-link>
   `,
+  isInteractive: true,
 };

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -91,31 +91,31 @@ const Template = ({
 
 export const Information = Template.bind({});
 Information.args = {
-  defaultSlot: html` Here is an informational message. `,
+  defaultSlot: html`Here is an informational message.`,
   statusType: 'information',
 };
 
 export const Warning = Template.bind({});
 Warning.args = {
-  defaultSlot: html` Here is a warning message. `,
+  defaultSlot: html`Here is a warning message.`,
   statusType: 'warning',
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  defaultSlot: html` Here is an error message. `,
+  defaultSlot: html`Here is an error message.`,
   statusType: 'error',
 };
 
 export const Success = Template.bind({});
 Success.args = {
-  defaultSlot: html` Here is a success message. `,
+  defaultSlot: html`Here is a success message.`,
   statusType: 'success',
 };
 
 export const Small = Template.bind({});
 Small.args = {
-  defaultSlot: html` Here is a small alert message. `,
+  defaultSlot: html`Here is a small alert message.`,
   size: 'small',
 };
 

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -57,6 +57,8 @@ You can use a smaller alert with \`size\` of \`small\`.
 
 You can remove the icon with \`shouldShowIcon\` set to \`false\`.
 
+You can customize the header by adding a \`outline-alert--header\` slot.
+
 ## Accessibility
 
 If the alert has an interaction, you should indicate this with \`isInteractive\` set to \`true\`.

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -106,6 +106,10 @@ Small.args = {
 
 export const Header = Template.bind({});
 Header.args = {
-  headerSlot: html`<span slot="outline-alert--header">Here is an alert with a custom header.</span>`,
+  headerSlot: html`
+    <span slot="outline-alert--header">
+      Here is an alert with a custom header.
+    </span>
+  `,
   defaultSlot: html` Here is a message. `,
 };

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -94,8 +94,8 @@ const Template = ({
     <outline-alert
       statusType="${ifDefined(statusType)}"
       size="${ifDefined(size)}"
-      shouldShowIcon="${ifDefined(shouldShowIcon)}"
-      isInteractive="${ifDefined(isInteractive)}"
+      shouldShowIcon="${ifDefined(shouldShowIcon ? 'true' : undefined)}"
+      isInteractive="${ifDefined(isInteractive ? 'true' : undefined)}"
     >
       ${ifDefined(headerSlot)} ${ifDefined(defaultSlot)}
     </outline-alert>

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -49,7 +49,7 @@ This component renders an alert.
   statusType="{{ statusType }}"
   size="{{ size }}"
 >
-  <outline-heading slot="outline-alert--header">{{ headerSlot }}</outline-heading>
+  <span slot="outline-alert--header">{{ headerSlot }}</span>
   {{ defaultSlot }}
 </outline-alert>
         `,
@@ -106,6 +106,6 @@ Small.args = {
 
 export const Header = Template.bind({});
 Header.args = {
-  headerSlot: html` Here is an alert with a custom header. `,
+  headerSlot: html`<span slot="outline-alert--header">Here is an alert with a custom header.</span>`,
   defaultSlot: html` Here is a message. `,
 };

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -34,12 +34,24 @@ export default {
       options: alertSizes,
       control: { type: 'select' },
     },
+    shouldShowIcon: {
+      description: '(not yet implemented) Should we show the icon',
+      control: { type: 'boolean' },
+    },
   },
   parameters: {
     docs: {
       description: {
         component: `
 This component renders an alert.
+
+## Variation
+
+You can set the type of alert with \`statusType\`.
+
+You can use a smaller alert with \`size\` of \`small\`.
+
+You can remove the icon with \`shouldShowIcon\` set to \`false\`.
 `,
       },
       source: {
@@ -48,6 +60,7 @@ This component renders an alert.
 <outline-alert
   statusType="{{ statusType }}"
   size="{{ size }}"
+  shouldShowIcon="{{ shouldShowIcon }}"
 >
   <span slot="outline-alert--header">{{ headerSlot }}</span>
   {{ defaultSlot }}
@@ -63,11 +76,13 @@ const Template = ({
   defaultSlot,
   statusType,
   size,
+  shouldShowIcon,
 }): TemplateResult => {
   return html`
     <outline-alert
       statusType="${ifDefined(statusType)}"
       size="${ifDefined(size)}"
+      shouldShowIcon="${ifDefined(shouldShowIcon)}"
     >
       ${ifDefined(headerSlot)} ${ifDefined(defaultSlot)}
     </outline-alert>
@@ -112,4 +127,10 @@ Header.args = {
     </span>
   `,
   defaultSlot: html` Here is a message. `,
+};
+
+export const NoIcon = Template.bind({});
+NoIcon.args = {
+  defaultSlot: html`Here is an alert with no icon.`,
+  shouldShowIcon: false,
 };

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -134,3 +134,11 @@ NoIcon.args = {
   defaultSlot: html`Here is an alert with no icon.`,
   shouldShowIcon: false,
 };
+
+export const MessageWithLink = Template.bind({});
+MessageWithLink.args = {
+  defaultSlot: html`
+    Here is an alert with a link.
+    <outline-link linkhref="#">Click here</outline-link>
+  `,
+};

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -1,0 +1,111 @@
+import { html, TemplateResult } from 'lit';
+import './outline-alert';
+import { argTypeSlotContent } from '../../base/outline-element/utils/utils';
+import { alertSizes, alertStatusTypes } from './outline-alert';
+import { ifDefined } from 'lit/directives/if-defined';
+
+export default {
+  title: 'Molecules/Alert',
+  component: 'outline-alert',
+  argTypes: {
+    headerSlot: {
+      name: 'slot="outline-alert--header"',
+      description: 'The header slot. For example a header title.',
+      table: {
+        category: 'Slots',
+      },
+      // We aren't setting a control type here so we can edit the value using the infered object.
+    },
+    // We aren't setting a control type here so we can edit the value using the infered object.
+    defaultSlot: {
+      ...argTypeSlotContent.defaultSlot,
+      table: {
+        category: 'Slots',
+      },
+    },
+    statusType: {
+      description:
+        'The status type of the alert. Such as `information` or `warning`.',
+      options: alertStatusTypes,
+      control: { type: 'select' },
+    },
+    size: {
+      description: 'The size of the alert.',
+      options: alertSizes,
+      control: { type: 'select' },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This component renders an alert.
+`,
+      },
+      source: {
+        // This code sample will be used for every example unless overridden.
+        code: `
+<outline-alert
+  statusType="{{ statusType }}"
+  size="{{ size }}"
+>
+  <outline-heading slot="outline-alert--header">{{ headerSlot }}</outline-heading>
+  {{ defaultSlot }}
+</outline-alert>
+        `,
+      },
+    },
+  },
+};
+
+const Template = ({
+  headerSlot,
+  defaultSlot,
+  statusType,
+  size,
+}): TemplateResult => {
+  return html`
+    <outline-alert
+      statusType="${ifDefined(statusType)}"
+      size="${ifDefined(size)}"
+    >
+      ${ifDefined(headerSlot)} ${ifDefined(defaultSlot)}
+    </outline-alert>
+  `;
+};
+
+export const Information = Template.bind({});
+Information.args = {
+  defaultSlot: html` Here is an informational message. `,
+  statusType: 'information',
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  defaultSlot: html` Here is a warning message. `,
+  statusType: 'warning',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  defaultSlot: html` Here is an error message. `,
+  statusType: 'error',
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  defaultSlot: html` Here is a success message. `,
+  statusType: 'success',
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  defaultSlot: html` Here is a small alert message. `,
+  size: 'small',
+};
+
+export const Header = Template.bind({});
+Header.args = {
+  headerSlot: html` Here is an alert with a custom header. `,
+  defaultSlot: html` Here is a message. `,
+};

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -94,8 +94,8 @@ const Template = ({
     <outline-alert
       statusType="${ifDefined(statusType)}"
       size="${ifDefined(size)}"
-      shouldShowIcon="${ifDefined(shouldShowIcon ? 'true' : undefined)}"
-      isInteractive="${ifDefined(isInteractive ? 'true' : undefined)}"
+      ?shouldShowIcon="${shouldShowIcon}"
+      ?isInteractive="${isInteractive}"
     >
       ${ifDefined(headerSlot)} ${ifDefined(defaultSlot)}
     </outline-alert>

--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -70,8 +70,8 @@ If the alert has an interaction, you should indicate this with \`isInteractive\`
 <outline-alert
   statusType="{{ statusType }}"
   size="{{ size }}"
-  shouldShowIcon="{{ shouldShowIcon }}"
-  isInteractive="{{ isInteractive }}"
+  {{ shouldShowIcon }}
+  {{ isInteractive }}
 >
   <span slot="outline-alert--header">{{ headerSlot }}</span>
   {{ defaultSlot }}

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -34,10 +34,13 @@ export class OutlineAlert extends OutlineElement {
   @property({ type: Boolean })
   shouldShowIcon = true;
 
+  @property({ type: Boolean })
+  isInteractive = false;
+
   render(): TemplateResult {
     // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
-      <div id="body">
+      <div id="body" role="${this.isInteractive ? 'alertdialog' : 'alert'}">
         ${this._iconTemplate()} ${this._headerTemplate()}
         <div id="message">
           <slot></slot>

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -1,0 +1,40 @@
+import { html, TemplateResult, CSSResultGroup } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import componentStyles from './outline-alert.css.lit';
+import { OutlineElement } from '../outline-element/outline-element';
+
+export type AlertSize = 'small' | 'large';
+export const alertSizes: AlertSize[] = ['small', 'large'];
+
+export type AlertStatusType = 'information' | 'warning' | 'error' | 'success';
+export const alertStatusTypes: AlertStatusType[] = [
+  'information',
+  'warning',
+  'error',
+  'success',
+];
+
+/**
+ * The Outline Alert component
+ *
+ * @element outline-alert
+ * @slot default - The alert contents
+ * @slot outline-alert--header - The header in the alert
+ */
+@customElement('outline-alert')
+export class OutlineAlert extends OutlineElement {
+  static styles: CSSResultGroup = [componentStyles];
+
+  @property({ type: String })
+  size?: AlertSize = 'large';
+
+  @property({ type: String })
+  statusType?: AlertStatusType = 'information';
+
+  render(): TemplateResult {
+    return html`
+      <slot name="outline-alert--header">Information</slot>
+      <slot></slot>
+    `;
+  }
+}

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -25,18 +25,6 @@ export const alertStatusTypes: AlertStatusType[] = [
 export class OutlineAlert extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
-  @property({ type: String })
-  size: AlertSize = 'large';
-
-  @property({ type: String })
-  statusType: AlertStatusType = 'information';
-
-  @property({ type: Boolean })
-  shouldShowIcon = true;
-
-  @property({ type: Boolean })
-  isInteractive = false;
-
   render(): TemplateResult {
     // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
@@ -48,6 +36,9 @@ export class OutlineAlert extends OutlineElement {
       </div>
     `;
   }
+
+  @property({ type: Boolean })
+  isInteractive = false;
 
   private _iconTemplate(): TemplateResult {
     let template = html``;
@@ -62,6 +53,9 @@ export class OutlineAlert extends OutlineElement {
 
     return template;
   }
+
+  @property({ type: Boolean })
+  shouldShowIcon = true;
 
   private _headerTemplate(): TemplateResult {
     let template = html``;
@@ -79,4 +73,10 @@ export class OutlineAlert extends OutlineElement {
 
     return template;
   }
+
+  @property({ type: String })
+  size: AlertSize = 'large';
+
+  @property({ type: String })
+  statusType: AlertStatusType = 'information';
 }

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -29,7 +29,20 @@ export class OutlineAlert extends OutlineElement {
     // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
       <div id="body" role="${this.isInteractive ? 'alertdialog' : 'alert'}">
-        ${this._iconTemplate()} ${this._headerTemplate()}
+        ${this.shouldShowIcon === true
+          ? html`
+              <div id="icon">
+                <!--@todo include icon when we have that ready.-->
+              </div>
+            `
+          : html``}
+        ${this.size === 'large'
+          ? html`
+              <div id="header">
+                <slot name="outline-alert--header">${this.statusType}</slot>
+              </div>
+            `
+          : html``}
         <div id="message">
           <slot></slot>
         </div>
@@ -40,36 +53,8 @@ export class OutlineAlert extends OutlineElement {
   @property({ type: Boolean })
   isInteractive = false;
 
-  private _iconTemplate(): TemplateResult {
-    let template = html``;
-
-    if (this.shouldShowIcon === true) {
-      template = html`
-        <div id="icon">
-          <!--@todo include icon when we have that ready.-->
-        </div>
-      `;
-    }
-
-    return template;
-  }
-
   @property({ type: Boolean })
   shouldShowIcon = true;
-
-  private _headerTemplate(): TemplateResult {
-    let template = html``;
-
-    if (this.size === 'large') {
-      template = html`
-        <div id="header">
-          <slot name="outline-alert--header">${this.statusType}</slot>
-        </div>
-      `;
-    }
-
-    return template;
-  }
 
   @property({ type: String })
   size: AlertSize = 'large';

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -31,16 +31,33 @@ export class OutlineAlert extends OutlineElement {
   @property({ type: String })
   statusType: AlertStatusType = 'information';
 
+  @property({ type: Boolean })
+  shouldShowIcon = true;
+
   render(): TemplateResult {
     // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
       <div id="body">
-        ${this._headerTemplate()}
+        ${this._iconTemplate()} ${this._headerTemplate()}
         <div id="message">
           <slot></slot>
         </div>
       </div>
     `;
+  }
+
+  private _iconTemplate(): TemplateResult {
+    let template = html``;
+
+    if (this.shouldShowIcon === true) {
+      template = html`
+        <div id="icon">
+          <!--@todo include icon when we have that ready.-->
+        </div>
+      `;
+    }
+
+    return template;
   }
 
   private _headerTemplate(): TemplateResult {

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -63,10 +63,7 @@ export class OutlineAlert extends OutlineElement {
     if (this.size === 'large') {
       template = html`
         <div id="header">
-          <slot name="outline-alert--header">
-            ${this.statusType.charAt(0).toUpperCase() +
-            this.statusType.slice(1)}
-          </slot>
+          <slot name="outline-alert--header">${this.statusType}</slot>
         </div>
       `;
     }

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import componentStyles from './outline-alert.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -26,14 +26,16 @@ export class OutlineAlert extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
   @property({ type: String })
-  size?: AlertSize = 'large';
+  size: AlertSize = 'large';
 
   @property({ type: String })
-  statusType?: AlertStatusType = 'information';
+  statusType: AlertStatusType = 'information';
 
   render(): TemplateResult {
     return html`
-      <slot name="outline-alert--header">Information</slot>
+      <slot name="outline-alert--header">
+        ${this.statusType.charAt(0).toUpperCase() + this.statusType.slice(1)}
+      </slot>
       <slot></slot>
     `;
   }

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -14,6 +14,14 @@ export const alertStatusTypes: AlertStatusType[] = [
   'success',
 ];
 
+// This can be useful for testing.
+export interface OutlineAlertInterface extends HTMLElement {
+  statusType: AlertStatusType;
+  size: AlertSize;
+  isInteractive: Boolean;
+  shouldShowIcon: Boolean;
+}
+
 /**
  * The Outline Alert component
  *
@@ -22,7 +30,10 @@ export const alertStatusTypes: AlertStatusType[] = [
  * @slot outline-alert--header - The header in the alert
  */
 @customElement('outline-alert')
-export class OutlineAlert extends OutlineElement {
+export class OutlineAlert
+  extends OutlineElement
+  implements OutlineAlertInterface
+{
   static styles: CSSResultGroup = [componentStyles];
 
   @property({ type: String })

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -3,16 +3,16 @@ import { customElement, property } from 'lit/decorators.js';
 import componentStyles from './outline-alert.css.lit';
 import { OutlineElement } from '../outline-element/outline-element';
 
-export type AlertSize = 'small' | 'large';
-export const alertSizes: AlertSize[] = ['small', 'large'];
+export const alertSizes = ['small', 'large'] as const;
+export type AlertSize = typeof alertSizes[number];
 
-export type AlertStatusType = 'information' | 'warning' | 'error' | 'success';
-export const alertStatusTypes: AlertStatusType[] = [
+export const alertStatusTypes = [
   'information',
   'warning',
   'error',
   'success',
-];
+] as const;
+export type AlertStatusType = typeof alertStatusTypes[number];
 
 // This can be useful for testing.
 export interface OutlineAlertInterface extends HTMLElement {

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -32,11 +32,31 @@ export class OutlineAlert extends OutlineElement {
   statusType: AlertStatusType = 'information';
 
   render(): TemplateResult {
+    // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
-      <slot name="outline-alert--header">
-        ${this.statusType.charAt(0).toUpperCase() + this.statusType.slice(1)}
-      </slot>
-      <slot></slot>
+      <div id="body">
+        ${this._headerTemplate()}
+        <div id="message">
+          <slot></slot>
+        </div>
+      </div>
     `;
+  }
+
+  private _headerTemplate(): TemplateResult {
+    let template = html``;
+
+    if (this.size === 'large') {
+      template = html`
+        <div id="header">
+          <slot name="outline-alert--header">
+            ${this.statusType.charAt(0).toUpperCase() +
+            this.statusType.slice(1)}
+          </slot>
+        </div>
+      `;
+    }
+
+    return template;
   }
 }

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -50,14 +50,14 @@ export class OutlineAlert extends OutlineElement {
                 <!--@todo include icon when we have that ready.-->
               </div>
             `
-          : html``}
+          : null}
         ${this.size === 'large'
           ? html`
               <div id="header">
                 <slot name="outline-alert--header">${this.statusType}</slot>
               </div>
             `
-          : html``}
+          : null}
         <div id="message">
           <slot></slot>
         </div>

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -25,6 +25,21 @@ export const alertStatusTypes: AlertStatusType[] = [
 export class OutlineAlert extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
+  @property({ type: String })
+  statusType: AlertStatusType = 'information';
+
+  /**
+   * This is important context for screen readers.
+   */
+  @property({ type: Boolean })
+  isInteractive = false;
+
+  @property({ type: Boolean })
+  shouldShowIcon = true;
+
+  @property({ type: String })
+  size: AlertSize = 'large';
+
   render(): TemplateResult {
     // The `body` wrapper is used to avoid styles (like border) that are preventing us from styling `:host`.
     return html`
@@ -49,16 +64,4 @@ export class OutlineAlert extends OutlineElement {
       </div>
     `;
   }
-
-  @property({ type: Boolean })
-  isInteractive = false;
-
-  @property({ type: Boolean })
-  shouldShowIcon = true;
-
-  @property({ type: String })
-  size: AlertSize = 'large';
-
-  @property({ type: String })
-  statusType: AlertStatusType = 'information';
 }

--- a/src/components/base/outline-alert/test/outline-alert.test.ts
+++ b/src/components/base/outline-alert/test/outline-alert.test.ts
@@ -1,0 +1,60 @@
+import { OutlineAlert as OutlineComponent } from '../outline-alert';
+import { expect, waitUntil } from '@open-wc/testing';
+
+// We are using these generic names so we can hopefully generalize this process or at least make copy & paste easier.
+const componentElementName = 'outline-alert';
+
+describe(componentElementName, () => {
+  // We don't get base styles automatically. Is there a better way?
+  const addBaseStyles = () => {
+    const defaultCSS = document.createElement('link');
+    defaultCSS.setAttribute('rel', 'stylesheet');
+    defaultCSS.setAttribute('href', '/outline.theme.css');
+
+    document.head.append(defaultCSS);
+  };
+
+  before(() => {
+    addBaseStyles();
+  });
+
+  it('Make sure to load necessary component JS', () => {
+    // If we don't use the component at least once, its JS will never be loaded and the component won't render. :(
+    const componentElement = document.createElement(componentElementName);
+
+    expect(componentElement).is.instanceOf(OutlineComponent);
+  });
+
+  it('Slot message.', () => {
+    const alertElement = document.createElement(componentElementName);
+
+    const messageElement = document.createElement('p');
+    messageElement.innerText = 'Test message';
+    alertElement.append(messageElement);
+
+    document.body.append(alertElement);
+
+    // Wait for the component to render. :(
+
+    waitUntil(
+      () => messageElement.assignedSlot !== null,
+      'Message is slotted.'
+    );
+  });
+
+  it('Slot header.', () => {
+    const alertElement = document.createElement(componentElementName);
+
+    const headerSlotElement = document.createElement('span');
+    headerSlotElement.setAttribute('slot', 'outline-alert--header');
+    headerSlotElement.innerText = 'Test header text';
+    alertElement.append(headerSlotElement);
+
+    document.body.append(alertElement);
+
+    waitUntil(
+      () => headerSlotElement.assignedSlot !== null,
+      'Header is slotted.'
+    );
+  });
+});


### PR DESCRIPTION
# Description

Adds an alert. See #41.

# Testing notes
- Visit http://localhost:6006/?path=/docs/molecules-alert--information and similar examples.

# Example

![alert](https://user-images.githubusercontent.com/397902/126009374-f1007fb4-f314-46f1-a795-61e6af1fe1a8.jpg)

# Notes

Took styling and types mostly from https://github.com/phase2/outline/issues/41.

This doesn't render an icon yet since there are still some open questions around that.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/60"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

