### PR TITLE
Rollup configuration updates

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,16 @@ import svg from 'rollup-plugin-svg';
 
 export default {
   // Output all components to a single exported file.
-  input: 'src/components/**/*[!(stories|lit)].ts',
+  input: {
+    include: [
+      'src/components/**/*.ts',
+    ],
+    exclude: [
+      'src/components/**/*.stories.ts',
+      'src/components/**/*.css.lit.ts',
+      'src/components/**/*.test.ts',
+    ],
+  },
   output: [
     {
       // Modern bundle.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,9 +9,7 @@ import svg from 'rollup-plugin-svg';
 export default {
   // Output all components to a single exported file.
   input: {
-    include: [
-      'src/components/**/*.ts',
-    ],
+    include: ['src/components/**/*.ts'],
     exclude: [
       'src/components/**/*.stories.ts',
       'src/components/**/*.css.lit.ts',


### PR DESCRIPTION
These should not be included.
They also make the package too large for a single file and cause errors / some things to not be included.

## Testing steps

```
yarn install
yarn rollup
```

Confirm you don't get errors with `yarn rollup`.

View the `dist/outline.js` file and search for `my-element`.

Could also test with #75.

## Notes

See #79 

This may not be a permanent fix, but it seems to work for now. If the repository becomes too large, I think we'll hit the same issue and need to see if there is another solution.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/80"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

