### PR TITLE
fix: remove Gitpod button from PR comments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,7 +36,7 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)


### PR DESCRIPTION
# The Problem/Issue/Bug
The `Open with Gitpod` badge in PR comments is redundant.


## How this PR Solves The Problem
Changing the settings in `.gitpod.yml` to display the badge only in the PR description.

## Manual Testing Instructions
Look at the page of this PR, it should have only 1 badge in the description 
🙏 

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/81"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

