### PR TITLE
feat(outline-accordion): update to match smc implementation, splits o…

### DIFF
--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.css
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.css
@@ -1,0 +1,73 @@
+.accordion-button {
+  @apply flex justify-between text-2xl font-body font-medium border-0 items-center w-full pl-8 pr-0 py-0;
+}
+
+.accordion-button.mobile {
+  @apply pl-4 pr-0 py-0 text-base leading-5 !important;
+}
+
+.accordion-button.active {
+  @apply bg-blue-700 text-neutral-white;
+}
+
+.accordion-button.inactive {
+  @apply bg-neutral-white text-blue-700;
+}
+
+.accordion-button.clean {
+  @apply border-b border-solid border-gray-200;
+}
+
+.accordion-button.clean.active {
+  @apply bg-neutral-white text-blue-300 !important;
+}
+
+.accordion-button.clean.inactive {
+  @apply text-blue-700;
+}
+
+.accordion-content {
+  @apply px-8 pt-4 text-gray-700;
+}
+
+.accordion-content.mobile {
+  @apply px-4;
+}
+
+.accordion-label {
+  @apply text-left py-4;
+  max-width: 75%;
+}
+
+.accordion-label.mobile {
+  @apply py-2;
+}
+
+.accordion-heading {
+  @apply m-0 flex;
+  min-height: 4rem;
+}
+
+.accordion-icon {
+  @apply flex w-20 h-full items-center justify-center;
+}
+
+.accordion-icon.clean {
+  @apply text-blue-500 bg-neutral-white !important;
+}
+
+.accordion-icon.active {
+  @apply text-neutral-white bg-blue-600;
+}
+
+.accordion-icon.inactive {
+  @apply text-blue-700 bg-blue-300;
+}
+
+.accordion-panel {
+  @apply flex mb-6 rounded-md flex-col overflow-hidden border border-solid border-gray-200;
+}
+
+.accordion-panel.clean {
+  @apply border-0;
+}

--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.stories.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.stories.ts
@@ -1,0 +1,84 @@
+import { html, TemplateResult } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import './outline-accordion-panel';
+
+export default {
+  title: 'Content/Accordion/Accordion Panel',
+  component: 'outline-accordion-panel',
+  parameters: {
+    docs: {
+      source: {
+        code: `<outline-accordion-panel clean=clean active=active>
+                <h3 slot="heading">Panel the First</h3>
+                <div class="wysiwyg">
+                  <h3>Etiam ut purus mattis mauris</h3>
+                  <p>Suspendisse eu ligula.Proin pretium,
+                   leo ac pellentesque mollis, felis nunc ultrices eros,
+                   sed gravida augue augue mollis justo.Maecenas ullamcorper,
+                   dui et placerat feugiat, eros pede varius nisi,
+                   condimentum viverra felis nunc et lorem.
+                   Nam at tortor in tellus interdum sagittis.
+                   Morbi ac felis.Etiam ultricies nisi vel augue.
+                   Praesent venenatis metus at tortor pulvinar varius.
+                   Sed cursus turpis vitae tortor.Donec elit libero,
+                   sodales nec, volutpat a, suscipit non, turpis.
+                   Fusce vulputate eleifend sapien.
+                   </p>
+                </div >
+              </outline-accordion-panel>`,
+      },
+    },
+  },
+  argTypes: {
+    clean: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        '**`<Boolean>`**: Sets the panel to the "clean" variant. <br> Controlled by the parent `<outline-accordion>` component.',
+    },
+    active: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        '**`<Boolean>`**: Sets the panel to active/open. <br> Controlled by the parent `<outline-accordion>` component.',
+    },
+    headingSlotContent: {
+      name: 'Heading slot content',
+      control: { type: 'text' },
+      description: '**NOT A PROP**: Text for the heading.',
+    },
+    defaultSlotContent: {
+      name: 'Default slot content',
+      control: { type: 'text' },
+      description: '**NOT A PROP**: Markup for the main panel content.',
+    },
+  },
+  args: {
+    clean: false,
+    active: false,
+    headingSlotContent: '<h5 slot="heading">Panel the First</h5>',
+    defaultSlotContent:
+      '<div class="wysiwyg"><h6>Etiam ut purus mattis mauris</h6><p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p></div>',
+  },
+};
+
+const Template = ({
+  clean,
+  active,
+  headingSlotContent,
+  defaultSlotContent,
+}): TemplateResult =>
+  html`
+    <outline-accordion-panel ?clean=${clean} ?active=${active}>
+      ${unsafeHTML(`${headingSlotContent}`)}
+      ${unsafeHTML(`${defaultSlotContent}`)}
+    </outline-accordion-panel>
+  `;
+
+export const AccordionPanel = Template.bind({});
+AccordionPanel.args = {
+  clean: false,
+  active: false,
+};

--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
@@ -1,0 +1,88 @@
+import { CSSResultGroup, TemplateResult, html } from 'lit';
+import { OutlineElement } from '../outline-element/outline-element';
+import { customElement, property } from 'lit/decorators.js';
+import componentStyles from './outline-accordion-panel.css.lit';
+import { MobileController } from '../../controllers/mobile-controller';
+import '../outline-icon/outline-icon';
+
+/**
+ * The OutlineAccordionPanel component
+ * @element outline-accordion-panel
+ * @slot heading: The title text for the panel component.
+ * @slot default slot: The main panel content, visible when the panel is open.
+ */
+@customElement('outline-accordion-panel')
+export class OutlineAccordionPanel extends OutlineElement {
+  private mobileController = new MobileController(this);
+
+  static styles: CSSResultGroup = [componentStyles];
+
+  /**
+   * Sets to 'clean' variant.
+   * Controlled by parent accordion component.
+   */
+  @property({ type: Boolean })
+  clean = false;
+
+  /**
+   * Wether the panel is active/open.
+   * Controlled by parent accordion component.
+   */
+  @property({ type: Boolean })
+  active = false;
+
+  /**
+   * Used to provided a unique ID
+   * for accordion component and accessibility purposes.
+   */
+  @property({ type: String, reflect: true })
+  id: string = Math.floor(Math.random() * 10000).toString();
+
+  render(): TemplateResult {
+    const isMobile = this.mobileController.isMobile ? 'mobile' : null;
+    const isClean = this.clean ? 'clean' : null;
+    const isActive = this.active ? 'active' : 'inactive';
+
+    return html` <div class="accordion-panel ${isClean}">
+      <h4 class="accordion-heading">
+        <button
+          class="accordion-button
+        ${isMobile}
+        ${isActive}
+        ${isClean}
+        "
+          id="${this.id}-button"
+          aria-expanded=${this.active}
+          aria-controls="${this.id}-info"
+        >
+          <span class="accordion-label ${isMobile}">
+            <slot name="heading"> </slot>
+          </span>
+          <span
+            class="accordion-icon
+          ${isMobile}
+          ${isActive}
+          ${isClean}
+          "
+          >
+            <outline-icon
+              size="22px"
+              ?decorative="${true}"
+              name="${this.active ? 'chevron-up' : 'chevron-down'}"
+            ></outline-icon>
+          </span>
+        </button>
+      </h4>
+      <div
+        class="accordion-content ${isMobile}"
+        role="region"
+        aria-labelledby="${this.id}-button"
+        id="${this.id}-info"
+        .hidden=${!this.active}
+        aria-hidden="${!this.active}"
+      >
+        <slot></slot>
+      </div>
+    </div>`;
+  }
+}

--- a/src/components/base/outline-accordion/outline-accordion.css
+++ b/src/components/base/outline-accordion/outline-accordion.css
@@ -1,19 +1,16 @@
-.accordion-button {
-  @apply border-0 bg-neutral-transparent;
+.accordion-title {
+  @apply text-blue-700 text-4xl font-display;
 }
 
-.accordion-panel {
-  border: black solid 2px;
-  border-top: none;
-}
-.accordion-heading {
-  @apply py-2 px-4;
+.accordion-title.mobile {
+  @apply text-blue-700 text-lg;
 }
 
-.accordion-heading {
-  @apply m-0;
+.accordion-title:after {
+  @apply flex w-8 border border-solid border-blue-700 my-6;
+  content: '';
 }
 
-div.accordion-panel:first-of-type {
-  border: black solid 2px;
+.accordion-title.mobile:after {
+  @apply w-4 border mt-2 mb-4;
 }

--- a/src/components/base/outline-accordion/outline-accordion.stories.ts
+++ b/src/components/base/outline-accordion/outline-accordion.stories.ts
@@ -1,45 +1,154 @@
 import { html, TemplateResult } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import './outline-accordion';
+import '../outline-accordion-panel/outline-accordion-panel';
 
 export default {
-  title: 'Molecules/Accordion',
+  title: 'Content/Accordion/Accordion',
   component: 'outline-accordion',
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <outline-accordion label=label clean=clean single-panel=singlePanel>
+    <outline-accordion-panel slot="panels">
+      <h5 slot="heading">Heading 1</h5>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+      <h5 slot="heading">Heading 2</h5>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+      <h5 slot="heading">Heading 3</h5>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+      <h5 slot="heading">Heading 4</h5>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+      <h5 slot="heading">Heading 5</h5>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+</outline-accordion>`,
+      },
+    },
+  },
   argTypes: {
-    singlePanel: {
+    label: {
+      control: {
+        type: 'text',
+      },
       description:
-        'Boolean attribute that determines if the accordion can have multiple panels opne at one time. Defaults to false.',
+        '**`String`**:<br> If a value is passed will create h4 header as title.',
+    },
+    allOpen: {
+      description:
+        '**`Boolean`**:<br> Attribute that determines if all the accordion panels start open. Currently just for the editor experience. Defaults to false.',
       control: {
         type: 'boolean',
       },
+      name: 'all open',
+      defaultValue: false,
     },
-    panels: {
+    singlePanel: {
       description:
-        'Takes an array of AccordioPanel objects. `{heading: string, content: any}`',
+        '**`Boolean`**:<br> Attribute that determines if the accordion can have multiple panels one at one time. Defaults to false.',
+      control: {
+        type: 'boolean',
+      },
+      name: 'single-panel',
     },
+    clean: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        '**`Boolean`**:<br> Sets the accordion to the "clean" variant.',
+    },
+    PanelsSlotContent: {
+      description:
+        '**Slot="panels"`<outline-accordion-panel>`**: <br> The only slot, named for query purposes. <br>Use only `<outline-accordion-panel>` components.',
+      name: 'Panels slot content',
+    },
+  },
+  args: {
+    label: 'Frequently Asked Questions',
+    PanelsSlotContent: `
+    <outline-accordion-panel slot="panels">
+    <h5 slot="heading">Heading 1</h5>
+    <div class='wysiwyg'>
+      <h6>Etiam ut purus mattis mauris</h6>
+      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
+    </div>
+    </outline-accordion-panel>
+
+<outline-accordion-panel slot="panels">
+    <h5 slot="heading">Heading 2</h5>
+    <div class="wysiwyg">
+      <h6>Etiam ut purus mattis mauris</h6>
+      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
+  </div>
+</outline-accordion-panel>
+
+<outline-accordion-panel slot="panels">
+    <h5 slot="heading">Heading 3</h5>
+    <div class="wysiwyg">
+      <h6>Etiam ut purus mattis mauris</h6>
+      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
+  </div>
+</outline-accordion-panel>
+
+<outline-accordion-panel slot="panels">
+    <h5 slot="heading">Heading 4</h5>
+    <div class="wysiwyg">
+      <h6>Etiam ut purus mattis mauris</h6>
+      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
+  </div>
+</outline-accordion-panel>`,
+    clean: false,
+    singlePanel: false,
   },
 };
 
-const Template = ({ panels, singlePanel }): TemplateResult =>
+const Template = ({
+  label,
+  clean,
+  singlePanel,
+  PanelsSlotContent,
+  allOpen,
+}): TemplateResult =>
   html`
-    <outline-accordion .panels=${panels} ?singlePanel=${singlePanel}>
+    <outline-accordion
+      label=${label}
+      ?clean=${clean}
+      ?single-panel=${singlePanel}
+      ?allOpen=${allOpen}
+    >
+      ${unsafeHTML(`${PanelsSlotContent}`)}
     </outline-accordion>
   `;
 
 export const Accordion = Template.bind({});
 Accordion.args = {
-  panels: [
-    {
-      heading: 'I am heading 1',
-      content: `<div class="test"><h3>I'm magic!!!</h3><p>Praesent ut ligula non mi</p></div> `,
-    },
-    {
-      heading: 'I am heading 2',
-      content: `<p>Praesent ut ligula non mi</p>`,
-    },
-    {
-      heading: 'I am heading 3',
-      content: `<p>Praesent ut ligula non mi</p>`,
-    },
-  ],
   singlePanel: false,
+  clean: false,
+  allOpen: true,
 };


### PR DESCRIPTION
feat(outline-accordion): update to match client implementation, splits out panel into sub component
## Note: ## Requires #118 
<img width="652" alt="Content___Accordion___Accordion_Panel_-_Accordion_Panel_⋅_Storybook" src="https://user-images.githubusercontent.com/11083407/136280163-84f9d713-42fd-4893-ad5d-e8191cad7f4a.png">

<img width="811" alt="Cursor_and_Content___Accordion___Accordion_-_Accordion_⋅_Storybook" src="https://user-images.githubusercontent.com/11083407/136280261-b06fad44-d324-4fef-863b-6a0d28c366ea.png">

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/117"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



