### PR TITLE
Add conditional slot template method to `outline-element`

### DIFF
--- a/src/components/base/outline-element/outline-element.ts
+++ b/src/components/base/outline-element/outline-element.ts
@@ -1,4 +1,6 @@
-import { LitElement } from 'lit';
+import { LitElement, TemplateResult } from 'lit';
+import { html, unsafeStatic } from 'lit/static-html.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { queryAll, queryAssignedNodes, customElement } from 'lit/decorators.js';
 //import componentStyles from './outline-element.base.css.lit';
 
@@ -36,4 +38,39 @@ export class OutlineElement extends LitElement {
   // render(): TemplateResult {
   //   return html``;
   // }
+
+  /**
+   * Create a conditional slot.
+   *
+   * Generates the slot if there is slotted content. Includes a wrapper:
+   * ```
+   * <div id="header">
+   *   <slot name="outline-element--header"></slot>
+   * </div>
+   * ```
+   */
+  protected _conditionalSlotTemplate({
+    elementName,
+    slotNameStub,
+    wrapperElementType = 'div',
+    ariaLabel = null,
+  }: {
+    elementName: string;
+    slotNameStub: string;
+    wrapperElementType?: string;
+    ariaLabel?: string | null;
+  }): TemplateResult | null {
+    const namespacedSlotName = `${elementName}--${slotNameStub}`;
+
+    return this.querySelector(`[slot="${namespacedSlotName}"]`) !== null
+      ? html`<${unsafeStatic(
+          wrapperElementType
+        )} id="${slotNameStub}" aria-label="${ifDefined(ariaLabel)}">
+          <slot
+            name="${namespacedSlotName}"
+            @slotchange="${() => this.requestUpdate()}"
+          ></slot>
+        </${unsafeStatic(wrapperElementType)}>`
+      : null;
+  }
 }


### PR DESCRIPTION
This is a feature we use on an internal project.

- Only renders the wrapper / slot when there is content
- Works when the slot content changes
- Supports other wrappers like `ul` if needed
- Supports accessible `aria-label` if set

I've found styling the wrappers to be more helpful than the slot content itself in most cases. For alignment / basic text styles. Even if the slotted content is expected to be there, the other features seem nice.

I don't always use it when the slot wrapper is more complex / needs siblings, etc. But most of the time, I just use this.

In the codebase, we use this pattern:

```TypeScript
import { html, TemplateResult, CSSResultGroup } from 'lit';
import { customElement, property } from 'lit/decorators.js';
import componentStyles from './example-video.css.lit';
import { OutlineElement } from '../../base/outline-element/outline-element';

const elementName = 'example-video';

export const videoPositions = ['left', 'right'] as const;
export type VideoPosition = typeof videoPositions[number];

export interface ExampleVideoInterface extends HTMLElement {
  videoPosition: VideoPosition;
}

/**
 * The Example video component
 *
 * @element example-video
 * @slot example-video--video - video
 * @slot example-video--heading - heading
 * @slot example-video--content - content
 * @slot example-video--footer - footer
 */
@customElement(elementName)
export class ExampleVideo
  extends OutlineElement
  implements ExampleVideoInterface
{
  static styles: CSSResultGroup = [componentStyles];

  @property({ type: String, reflect: true, attribute: 'video-position' })
  videoPosition: VideoPosition = 'left';

  render(): TemplateResult {
    return html`
      <div id="video-wrapper">
        ${this._conditionalSlotTemplate({
          elementName,
          slotNameStub: 'video',
        })}
        <div id="content-wrapper">
          ${this._conditionalSlotTemplate({
            elementName,
            slotNameStub: 'heading',
          })}
          ${this._conditionalSlotTemplate({
            elementName,
            slotNameStub: 'content',
          })}
          ${this._conditionalSlotTemplate({
            elementName,
            slotNameStub: 'footer',
          })}
        </div>
      </div>
    `;
  }
}
```

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/126"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

