### PR TITLE
fix: won't build without js references

### DIFF
--- a/src/components/base/outline-alert/outline-alert.stories.ts
+++ b/src/components/base/outline-alert/outline-alert.stories.ts
@@ -2,7 +2,7 @@ import { html, TemplateResult } from 'lit';
 import './outline-alert';
 import { argTypeSlotContent } from '../../base/outline-element/utils/utils';
 import { alertSizes, alertStatusTypes } from './outline-alert';
-import { ifDefined } from 'lit/directives/if-defined';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 export default {
   title: 'Molecules/Alert',

--- a/src/utilities/form-control.ts
+++ b/src/utilities/form-control.ts
@@ -1,6 +1,6 @@
 import { html, TemplateResult } from 'lit';
 import { classMap } from 'lit-html/directives/class-map';
-import { ifDefined } from 'lit-html/directives/if-defined';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export const renderFormControl = (
   props: {


### PR DESCRIPTION
I think an old PR was merged that passed when this wasn't required.

Current builds are failing because of this.

## To test
`yarn start`

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

