### PR TITLE
Vimeo Video component

### DIFF
--- a/src/components/base/outline-video-vimeo/outline-video-vimeo.css
+++ b/src/components/base/outline-video-vimeo/outline-video-vimeo.css
@@ -1,0 +1,10 @@
+/* See https://github.com/tailwindlabs/tailwindcss-aspect-ratio/blob/master/src/index.js */
+
+:host {
+  @apply block relative h-0;
+  padding-bottom: calc(9 / 16 * 100%);
+}
+
+iframe {
+  @apply block absolute top-0 bottom-0 left-0 right-0 w-full h-full;
+}

--- a/src/components/base/outline-video-vimeo/outline-video-vimeo.stories.ts
+++ b/src/components/base/outline-video-vimeo/outline-video-vimeo.stories.ts
@@ -1,0 +1,52 @@
+import { html, TemplateResult } from 'lit';
+import './outline-video-vimeo';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+const configuration = {
+  title: 'Content/Vimeo Video',
+  component: 'outline-video-vimeo',
+  argTypes: {
+    videoID: {
+      name: 'video-id',
+      description: 'Vimeo video id',
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    videoID: `253989945`,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Vimeo video. Allows the embedded video to fit the space.
+`,
+      },
+      source: {
+        // This code sample will be used for every example unless overridden.
+        code: `
+<outline-video-vimeo
+  video-id="{{ videoID }}"
+>
+</outline-video-vimeo>
+        `,
+      },
+    },
+  },
+};
+
+export default configuration;
+
+const Template = (args = configuration.args): TemplateResult => {
+  args = {
+    ...configuration.args,
+    ...args,
+  };
+
+  return html`
+    <outline-video-vimeo video-id="${ifDefined(args.videoID)}">
+    </outline-video-vimeo>
+  `;
+};
+
+export const VimeoVideo = Template.bind({});

--- a/src/components/base/outline-video-vimeo/outline-video-vimeo.ts
+++ b/src/components/base/outline-video-vimeo/outline-video-vimeo.ts
@@ -1,0 +1,36 @@
+import { html, TemplateResult, CSSResultGroup } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import componentStyles from './outline-video-vimeo.css.lit';
+import { OutlineElement } from '../../base/outline-element/outline-element';
+
+export interface OutlineVideoVimeoInterface extends HTMLElement {
+  videoID: string;
+}
+
+/**
+ * The Outline VideoVimeo component
+ *
+ * @element outline-video-vimeo
+ */
+@customElement('outline-video-vimeo')
+export class OutlineVideoVimeo
+  extends OutlineElement
+  implements OutlineVideoVimeoInterface
+{
+  static styles: CSSResultGroup = [componentStyles];
+
+  @property({ type: String, attribute: 'video-id', reflect: true })
+  videoID: string;
+
+  render(): TemplateResult {
+    return html`
+      <iframe
+        src="https://player.vimeo.com/video/${this.videoID}"
+        frameborder="0"
+        allow="autoplay; fullscreen; picture-in-picture"
+        allowfullscreen
+      ></iframe>
+      <script src="https://player.vimeo.com/api/player.js"></script>
+    `;
+  }
+}


### PR DESCRIPTION
Basic Vimeo video component that fits the available space.

Uses the same structure as Youtube Video.

If we want to use `aspect-ratio` the CSS can be

```css
iframe {
  @apply block w-full;

  aspect-ratio: 16/9;
}
```

We used this on an internal project and seems to work OK.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/136"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

