### PR TITLE
Fix(slotted controller) edge cases

### DIFF
--- a/src/components/base/outline-breadcrumbs/outline-breadcrumbs.css
+++ b/src/components/base/outline-breadcrumbs/outline-breadcrumbs.css
@@ -1,14 +1,11 @@
-a,
-::slotted(a) {
+a {
   @apply font-body text-demo-darkBlue transition-colors duration-300 no-underline;
 }
 
-a:hover,
-::slotted(a:hover) {
+a:hover {
   @apply text-demo-mediumBlue underline;
 }
 
-a.active,
-::slotted(a.active) {
+a.active {
   @apply underline;
 }

--- a/src/components/base/outline-card/outline-card.stories.ts
+++ b/src/components/base/outline-card/outline-card.stories.ts
@@ -249,3 +249,31 @@ CardWithHeaderAndFooter.args = {
     </div>
   `,
 };
+
+export const CardWithBreadcrumb = Template.bind({});
+CardWithBreadcrumb.args = {
+  cardFooter: html`
+    <div slot="header" class="p-4">
+      <outline-breadcrumbs>
+        <div class="breadbox">
+          <nav class="breadcrumb container-12">
+            <span>
+              <a href="#">Home</a>
+            </span>
+            <span>
+              <a href="#">About Us</a>
+            </span>
+            <span>
+              <a href="#">Our History</a>
+            </span>
+            <span class="last">
+              <a href="#" class="active">
+                That page that explains more about various things
+              </a>
+            </span>
+          </nav>
+        </div>
+      </outline-breadcrumbs>
+    </div>
+  `,
+};

--- a/src/components/controllers/slotted-controller.ts
+++ b/src/components/controllers/slotted-controller.ts
@@ -19,19 +19,40 @@ export class SlottedController implements ReactiveController {
   }
 
   onSlotChange() {
-    const elementName = this.hostEl.tagName;
-    const myElement: HTMLElement | null = this.hostEl.parentElement
-      ? this.hostEl.parentElement.querySelector(elementName)
-      : null;
-    if (myElement && myElement.shadowRoot) {
-      const slot: HTMLElement | null = myElement.shadowRoot.querySelector(
-        'slot'
-      )
-        ? myElement.shadowRoot.querySelector('slot')
-        : null;
-      if (slot) {
-        slot.append(...myElement.children);
-      }
+    // Search for all slots provided by the Web Component.
+    const slotsArray = this.hostEl.renderRoot.querySelectorAll('slot');
+
+    // If any slots found
+    if (slotsArray.length > 0) {
+      const currentElement = this.hostEl;
+      // Go through each slot shadow dom position
+      slotsArray.forEach(slot => {
+        // Process named slot
+        if (slot.name) {
+          // Fetch the corresponding named slot in the lightDom
+          const slotLightDom = currentElement.querySelector(
+            '[slot=' + slot.name + ']'
+          );
+          // Only if named slot found in light dom - move it into shadow DOM
+          if (slotLightDom) {
+            slot.before(slotLightDom);
+          }
+        }
+        // Process default (unnamed) slot
+        else {
+          // Get all content that doesn't have slot as attribute
+          const slotLightDomArray = Array.from(currentElement.children).filter(
+            node => {
+              return !node.getAttributeNode('slot');
+            }
+          );
+
+          // Move all unnamed slot content to the corresponding position in shadow DOM
+          slotLightDomArray.forEach(slotLightDom => {
+            slot.before(slotLightDom);
+          });
+        }
+      });
     }
   }
 }

--- a/src/components/controllers/slotted-controller.ts
+++ b/src/components/controllers/slotted-controller.ts
@@ -1,12 +1,16 @@
-import { ReactiveControllerHost, ReactiveController } from 'lit';
+import {
+  ReactiveControllerHost,
+  ReactiveController,
+  ReactiveElement,
+} from 'lit';
 
 export class SlottedController implements ReactiveController {
   host: ReactiveControllerHost;
-  hostEl: HTMLElement;
+  hostEl: ReactiveElement;
 
   constructor(host: ReactiveControllerHost) {
     (this.host = host).addController(this);
-    this.hostEl = this.host as unknown as HTMLElement;
+    this.hostEl = this.host as unknown as ReactiveElement;
   }
 
   hostConnected() {


### PR DESCRIPTION
# The Problem/Issue/Bug
When a web component that utilize slotted-controller is placed inside another web component, slotted-controller functionality breaks, and the slotted content is not displayed.

## How this PR Solves the Problem
This PR resolves additional edge cases for moving slotted content from Light DOM to Shadow DOM:
- Improved the way it finds accurately slotted content.
- Allow processing both named-slots and default-slots
- Doesn't break when there is no slotted content.
- and more :)

# Additional details

## Manual Testing Instructions
* `yarn start`
* Open this URL in browser: http://localhost:6006/?path=/docs/molecules-card--card-with-breadcrumb
* Inspect the breadcrumbs component inside the card component
* Confirm <slot></slot> is left empty
* Confirm all content is displayed in the Shadow DOM in its original order as it would in Light DOM.

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/141"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

