### PR TITLE
Testing Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
   # Job to run tests, linters and formatting checks.
   test:
-    name: Testing & Linting
+    name: Formatting & Linting
     runs-on: ubuntu-latest
     needs: setup
 
@@ -75,8 +75,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      # @see https://github.com/marketplace/actions/run-playwright-tests
-      - uses: microsoft/playwright-github-action@v1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -102,12 +100,9 @@ jobs:
       - name: Run prettier
         run: yarn lint.prettier
 
-      - name: Run tests
-        run: npx playwright install && yarn test
-
   # Job to build and cache the distribution package.
   build-dist:
-    name: Build Package(s)
+    name: Build & Test Package(s)
     runs-on: ubuntu-latest
     needs: test
 
@@ -150,6 +145,15 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      # @see https://github.com/marketplace/actions/run-playwright-tests
+      - uses: microsoft/playwright-github-action@v1  
+
+      - name: Setup playwright browsers
+        run: npx playwright install
+
+      - name: Run tests
+        run: yarn wtr
 
   build-storybook:
     name: Build Storybook

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         run: yarn lint.prettier
 
       - name: Run tests
-        run: yarn test
+        run: npx playwright install && yarn test
 
   # Job to build and cache the distribution package.
   build-dist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,8 @@ jobs:
       - name: Run prettier
         run: yarn lint.prettier
 
-      # - name: Run tests
-      #   run: yarn test
+      - name: Run tests
+        run: yarn test
 
   # Job to build and cache the distribution package.
   build-dist:

--- a/src/components/base/outline-breadcrumbs/test/outside-breadcrumbs.test.ts
+++ b/src/components/base/outline-breadcrumbs/test/outside-breadcrumbs.test.ts
@@ -9,6 +9,9 @@ describe('outline-breadcrumbs', () => {
 
   it('renders with default values', async () => {
     const el = await fixture(html`<outline-breadcrumbs></outline-breadcrumbs>`);
-    assert.shadowDom.equal(el, `<slot></slot>`);
+    assert.shadowDom.equal(
+      el,
+      `<div class="outline-breadcrumbs"><slot></slot></div>`
+    );
   });
 });

--- a/src/components/base/outline-button/test/outline-button.test.ts
+++ b/src/components/base/outline-button/test/outline-button.test.ts
@@ -12,7 +12,80 @@ describe('outline-button', () => {
     assert.shadowDom.equal(
       el,
       `
-      <button class="btn primary">
+      <button aria-disabled="false" class="btn medium primary">
+        <slot></slot>
+      </button>
+    `
+    );
+  });
+
+  it('renders as a link', async () => {
+    const el = await fixture(
+      html`<outline-button
+        url="https://outline.phase2tech.com"
+        target="_blank"
+      ></outline-button>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <a aria-disabled="false" class="btn medium primary" href="https://outline.phase2tech.com" target="_blank">
+        <slot></slot>
+      </a>
+    `
+    );
+  });
+
+  it('renders as a disabled button', async () => {
+    const el = await fixture(
+      html`<outline-button isDisabled></outline-button>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <button aria-disabled="true" class="btn medium primary">
+        <slot></slot>
+      </button>
+    `
+    );
+  });
+
+  it('renders a primary button variant', async () => {
+    const el = await fixture(
+      html`<outline-button variant="primary"></outline-button>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <button aria-disabled="false" class="btn medium primary">
+        <slot></slot>
+      </button>
+    `
+    );
+  });
+
+  it('renders a secondary button variant', async () => {
+    const el = await fixture(
+      html`<outline-button variant="secondary"></outline-button>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <button aria-disabled="false" class="btn medium secondary">
+        <slot></slot>
+      </button>
+    `
+    );
+  });
+
+  it('renders a tertiary variant', async () => {
+    const el = await fixture(
+      html`<outline-button variant="tertiary"></outline-button>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <button aria-disabled="false" class="btn medium tertiary">
         <slot></slot>
       </button>
     `


### PR DESCRIPTION
- Updated tests for `outline-breadcrumb` to match updated output.
- Updated tests for `outline-button` to:
  - Fix original broken (updated) expected markup
  - Add in multiple additional tests for various configurations
- Enable tests in GitHub Actions

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

