### PR TITLE
Updates for outline-container & outline-grid

### DIFF
--- a/outline.theme.css
+++ b/outline.theme.css
@@ -202,6 +202,6 @@
   /*
   * Configuration values for `outline-container`.
   */
-  --outline-container-padding-x: 1.5rem; 
+  --outline-container-padding-x: 1.5rem;
   --outline-container-padding-y: 1.5rem;
 }

--- a/outline.theme.css
+++ b/outline.theme.css
@@ -198,4 +198,10 @@
   --fw-bold: 700;
   --fw-extrabold: 800;
   --fw-black: 900;
+
+  /*
+  * Configuration values for `outline-container`.
+  */
+  --outline-container-padding-x: 1.5rem; 
+  --outline-container-padding-y: 1.5rem;
 }

--- a/src/.storybook/stories/documentation/tooling.stories.mdx
+++ b/src/.storybook/stories/documentation/tooling.stories.mdx
@@ -25,7 +25,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 # Outline Component Design
 
-<outline-grid gap-size="none" x-padding full-bleed>
+<outline-grid gap-size="none" full-bleed>
   <outline-column col-span-default="12">
     <div class="w-full">
       <img src={outlineBanner} />
@@ -34,7 +34,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 </outline-grid>
 <div class="text-xl pt-12 md:pt-24">
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding full-bleed="true">
+    <outline-grid gap-size="small" full-bleed="true">
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -82,7 +82,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding>
+    <outline-grid gap-size="small" >
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -157,7 +157,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding>
+    <outline-grid gap-size="small" >
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -216,7 +216,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding>
+    <outline-grid gap-size="small" >
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -306,7 +306,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
     </outline-grid>
   </div>
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding>
+    <outline-grid gap-size="small" >
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -362,7 +362,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
     </outline-grid>
   </div>
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" xPadding>
+    <outline-grid gap-size="small" >
       <outline-column
         col-span-default="12"
         col-span-md="2"

--- a/src/.storybook/stories/documentation/tooling.stories.mdx
+++ b/src/.storybook/stories/documentation/tooling.stories.mdx
@@ -25,7 +25,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
 
 # Outline Component Design
 
-<outline-grid gap-size="none" is-nested full-bleed>
+<outline-grid gap-size="none" x-padding full-bleed>
   <outline-column col-span-default="12">
     <div class="w-full">
       <img src={outlineBanner} />
@@ -34,7 +34,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
 </outline-grid>
 <div class="text-xl pt-12 md:pt-24">
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested full-bleed="true">
+    <outline-grid gap-size="small" xPadding full-bleed="true">
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -82,7 +82,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested>
+    <outline-grid gap-size="small" xPadding>
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -157,7 +157,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested>
+    <outline-grid gap-size="small" xPadding>
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -216,7 +216,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
     </outline-grid>
   </div>
   <div class="pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested>
+    <outline-grid gap-size="small" xPadding>
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -306,7 +306,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
     </outline-grid>
   </div>
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested>
+    <outline-grid gap-size="small" xPadding>
       <outline-column
         col-span-default="12"
         col-span-md="2"
@@ -362,7 +362,7 @@ import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
     </outline-grid>
   </div>
   <div class="w-full pb-10 md:pb-24">
-    <outline-grid gap-size="small" isNested>
+    <outline-grid gap-size="small" xPadding>
       <outline-column
         col-span-default="12"
         col-span-md="2"

--- a/src/.storybook/storybook-styles.css
+++ b/src/.storybook/storybook-styles.css
@@ -12,7 +12,7 @@
   @apply text-2xl font-display font-semibold border-none mb-4 !important;
 }
 .sbdocs .sbdocs-content {
-  max-width: 1440px;
+  max-width: 2240px;
 }
 .sbdocs-p {
   @apply mt-0 !important;

--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -1,42 +1,8 @@
 :host {
-  @apply block px-6 max-w-full-screen-w font-body;
+  @apply block p-6 max-w-full-screen-w font-body;
+  @apply sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl xxl:max-w-screen-xxl xxxl:max-w-screen-xxxl;
 }
 
-@screen sm {
-  :host {
-    @apply max-w-screen-sm;
-  }
-}
-
-@screen md {
-  :host {
-    @apply max-w-screen-md;
-  }
-}
-
-@screen lg {
-  :host {
-    @apply max-w-screen-lg;
-  }
-}
-
-@screen xl {
-  :host {
-    @apply max-w-screen-xl;
-  }
-}
-
-@screen xxl {
-  :host {
-    @apply max-w-screen-xxl;
-  }
-}
-
-@screen xxl {
-  :host {
-    @apply max-w-screen-xxxl;
-  }
-}
 :host(:not([is-nested])) {
   @apply px-0;
 }

--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -1,59 +1,31 @@
 :host {
-  @apply block p-6 max-w-full-screen-w font-body;
+  @apply block max-w-full-screen-w font-body;
   @apply sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl xxl:max-w-screen-xxl xxxl:max-w-screen-xxxl;
+  padding-top: var(--outline-container-padding-y);
+  padding-right: var(--outline-container-padding-x);
+  padding-bottom: var(--outline-container-padding-y);
+  padding-left: var(--outline-container-padding-x);
 }
 
-:host(:not([is-nested])) {
+:host(:not([x-padding])) {
   @apply px-0;
+}
+
+:host(:not([y-padding])) {
+  @apply py-0;
 }
 
 :host([full-bleed]) {
   @apply max-w-full;
 }
 
-@screen sm {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-@screen md {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-@screen lg {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-@screen xl {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-@screen xxl {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-@screen xxxl {
-  :host([full-bleed]) {
-    @apply max-w-full;
-  }
-}
-
-:host([container-align='left']) {
-  @apply ml-0 mr-auto;
-}
 :host([container-align]),
 :host([container-align='center']) {
   @apply mx-auto;
 }
+:host([container-align='left']) {
+  @apply mx-auto ml-0;
+}
 :host([container-align='right']) {
-  @apply ml-auto mr-0;
+  @apply mx-auto mr-0;
 }

--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -37,54 +37,46 @@
     @apply max-w-screen-xxxl;
   }
 }
-:host([is-nested]),
-:host([is-nested='true']) {
+:host(:not([is-nested])) {
   @apply px-0;
 }
 
-:host([full-bleed='']),
-:host([full-bleed='true']) {
+:host([full-bleed]) {
   @apply max-w-full;
 }
 
 @screen sm {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen md {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen lg {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen xl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]), {
     @apply max-w-full;
   }
 }
 
 @screen xxl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen xxxl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
@@ -92,7 +84,7 @@
 :host([container-align='left']) {
   @apply ml-0 mr-auto;
 }
-:host([container-align='']),
+:host([container-align]),
 :host([container-align='center']) {
   @apply mx-auto;
 }

--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -64,7 +64,7 @@
 }
 
 @screen xl {
-  :host([full-bleed]), {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }

--- a/src/components/base/outline-container/outline-container.stories.ts
+++ b/src/components/base/outline-container/outline-container.stories.ts
@@ -14,45 +14,65 @@ export default {
     //...argTypeSlotContent,
     containerAlign: {
       ...argTypeHorizontalAlign,
-      name: 'Alignment of the Container',
-      defaultValue: 'center',
+      name: 'Alignment',
+      description: 'How the container should align to the parent.',
+      table: { defaultValue: { summary: 'center' } },
     },
-    isNested: {
-      name: 'Padding',
+    xPadding: {
+      name: 'Padding: x-axis',
+      description: '',
+      table: { defaultValue: { summary: 'false' } },
+      control: {
+        type: 'boolean',
+      },
+    },
+    yPadding: {
+      name: 'Padding: y-axis',
+      description: '',
+      table: { defaultValue: { summary: 'false' } },
       control: {
         type: 'boolean',
       },
     },
     fullBleed: {
-      name: 'Full Bleed Container',
+      name: 'Full Bleed',
+      description:
+        'If the container should be full bleed and extend its left and right edges to edge of parent.',
+      table: { defaultValue: { summary: 'false' } },
       control: {
         type: 'boolean',
       },
     },
   },
+  args: {
+    containerAlign: 'center',
+    xPadding: true,
+    yPadding: true,
+    fullBleed: false,
+  },
 };
 
 interface Options {
-  isNested?: boolean;
+  xPadding?: boolean;
+  yPadding?: boolean;
   fullBleed?: boolean;
   containerAlign?: HorizontalAlignment;
 }
 
 export const Container = ({
-  isNested,
+  xPadding,
+  yPadding,
   fullBleed,
   containerAlign,
 }: Options): TemplateResult =>
   html`
     <outline-container
-      class="text-left rounded-xl border-2 border-dashed bg-demo-lightBlue border-demo-darkBlue py-10 md:py-20 my-10 md:my-20"
-      ?is-nested="${isNested}"
+      class="text-left rounded-xl border-2 border-dashed bg-demo-lightBlue border-demo-darkBlue my-10 md:my-20"
+      ?x-padding="${xPadding}"
+      ?y-padding="${yPadding}"
       ?full-bleed="${fullBleed}"
       container-align="${ifDefined(containerAlign)}"
     >
-      <!-- <outline-heading level="h2" level-size="2xl" class="mb-4"
-        >Container</outline-heading
-      > -->
       <p>
         This is text inside of a container. The various stylings of the element
         in demo mode are just here to show where the container starts and ends

--- a/src/components/base/outline-container/outline-container.stories.ts
+++ b/src/components/base/outline-container/outline-container.stories.ts
@@ -46,8 +46,8 @@ export const Container = ({
   html`
     <outline-container
       class="text-left rounded-xl border-2 border-dashed bg-demo-lightBlue border-demo-darkBlue py-10 md:py-20 my-10 md:my-20"
-      is-nested="${ifDefined(isNested)}"
-      full-bleed="${ifDefined(fullBleed)}"
+      ?is-nested="${isNested}"
+      ?full-bleed="${fullBleed}"
       container-align="${ifDefined(containerAlign)}"
     >
       <!-- <outline-heading level="h2" level-size="2xl" class="mb-4"

--- a/src/components/base/outline-container/outline-container.stories.ts
+++ b/src/components/base/outline-container/outline-container.stories.ts
@@ -11,7 +11,6 @@ export default {
     layout: 'fullscreen',
   },
   argTypes: {
-    //...argTypeSlotContent,
     containerAlign: {
       ...argTypeHorizontalAlign,
       name: 'Alignment',

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -18,6 +18,7 @@ export class OutlineContainer extends OutlineElement {
    */
   @property({
     type: Boolean,
+    reflect: true,
     attribute: 'is-nested',
   })
   isNested = false;

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -18,10 +18,9 @@ export class OutlineContainer extends OutlineElement {
    */
   @property({
     type: Boolean,
-    reflect: true,
     attribute: 'is-nested',
   })
-  isNested = true;
+  isNested = false;
 
   /**
    * Whether or not this is a full bleed container.

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -19,9 +19,19 @@ export class OutlineContainer extends OutlineElement {
   @property({
     type: Boolean,
     reflect: true,
-    attribute: 'is-nested',
+    attribute: 'x-padding',
   })
-  isNested = false;
+  xPadding = false;
+
+  /**
+   * Whether or not this container has padding.
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    attribute: 'y-padding',
+  })
+  yPadding = false;
 
   /**
    * Whether or not this is a full bleed container.

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -54,11 +54,7 @@ export class OutlineContainer extends OutlineElement {
   containerAlign: HorizontalAlignment = 'center';
 
   /**
-   * This methodology allows us to create a component that can use properties
-   * passed into it to generate a link element (<a>). This requires the linkHref
-   * attribute is passed, otherwise, anything passed in will override the default
-   * content in the slot allowing you to pass a pre-generated link into the
-   * outline-link component wrapper.
+   * Return the container element.
    */
   render(): TemplateResult {
     return html`<slot></slot>`;

--- a/src/components/base/outline-element/notes.ts
+++ b/src/components/base/outline-element/notes.ts
@@ -1,5 +1,0 @@
-/**
- * @file - Entry point for Outline to incorporate Lazy Loaded components.
- * @see https://lamplightdev.com/blog/2020/03/20/lazy-loading-web-components-with-intersection-observer/
- * @see https://github.com/lit/lit/tree/main/packages/labs/observers
- */

--- a/src/components/base/outline-element/notes.ts
+++ b/src/components/base/outline-element/notes.ts
@@ -1,0 +1,5 @@
+/**
+ * @file - Entry point for Outline to incorporate Lazy Loaded components.
+ * @see https://lamplightdev.com/blog/2020/03/20/lazy-loading-web-components-with-intersection-observer/
+ * @see https://github.com/lit/lit/tree/main/packages/labs/observers
+ */

--- a/src/components/base/outline-grid/outline-grid.css
+++ b/src/components/base/outline-grid/outline-grid.css
@@ -11,7 +11,8 @@ outline-container {
 :host([gap-size-md='large']) outline-container,
 :host([gap-size-lg='large']) outline-container,
 :host([gap-size-xl='large']) outline-container,
-:host([gap-size-xxl='large']) outline-container {
+:host([gap-size-xxl='large']) outline-container,
+:host([gap-size-xxxl='large']) outline-container {
   @apply gap-y-16 gap-x-0;
 }
 
@@ -20,7 +21,8 @@ outline-container {
 :host([gap-size-md='medium']) outline-container,
 :host([gap-size-lg='medium']) outline-container,
 :host([gap-size-xl='medium']) outline-container,
-:host([gap-size-xxl='medium']) outline-container {
+:host([gap-size-xxl='medium']) outline-container,
+:host([gap-size-xxxl='medium']) outline-container {
   @apply gap-y-10 gap-x-0;
 }
 
@@ -29,7 +31,8 @@ outline-container {
 :host([gap-size-md='small']) outline-container,
 :host([gap-size-lg='small']) outline-container,
 :host([gap-size-xl='small']) outline-container,
-:host([gap-size-xxl='small']) outline-container {
+:host([gap-size-xxl='small']) outline-container,
+:host([gap-size-xxxl='small']) outline-container {
   @apply gap-y-4 gap-x-0;
 }
 
@@ -167,6 +170,30 @@ outline-container {
 }
 
 @screen xxl {
+  :host([gap-size-xxl='none']) outline-container {
+    @apply gap-0;
+  }
+}
+
+@screen xxxl {
+  :host([gap-size-xxl='large']) outline-container {
+    @apply gap-y-16 gap-x-16;
+  }
+}
+
+@screen xxxl {
+  :host([gap-size-xxl='medium']) outline-container {
+    @apply gap-y-10 gap-x-10;
+  }
+}
+
+@screen xxxl {
+  :host([gap-size-xxl='small']) outline-container {
+    @apply gap-y-4 gap-x-4;
+  }
+}
+
+@screen xxxl {
   :host([gap-size-xxl='none']) outline-container {
     @apply gap-0;
   }

--- a/src/components/base/outline-grid/outline-grid.stories.ts
+++ b/src/components/base/outline-grid/outline-grid.stories.ts
@@ -1,7 +1,8 @@
 import { html, TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { Size } from '../outline-element/utils/types';
 
-import { argTypeGapSize } from '../outline-element/utils/utils';
+import { argTypeGapSize, argTypeHidden } from '../outline-element/utils/utils';
 import './outline-grid';
 
 export default {
@@ -11,53 +12,79 @@ export default {
     layout: 'fullscreen',
   },
   argTypes: {
+    defaultSlot: argTypeHidden,
     gapSize: {
       ...argTypeGapSize,
       name: 'Default Gap Size',
+      table: { defaultValue: { summary: 'small' } },
     },
     gapSizeSm: {
       ...argTypeGapSize,
       name: 'Gap Size on Small+',
+      table: { defaultValue: { summary: 'inherited' } },
     },
     gapSizeMd: {
       ...argTypeGapSize,
       name: 'Gap Size on Medium+',
+      table: { defaultValue: { summary: 'inherited' } },
     },
     gapSizeLg: {
       ...argTypeGapSize,
       name: 'Gap Size on Large+',
+      table: { defaultValue: { summary: 'inherited' } },
     },
     gapSizeXl: {
       ...argTypeGapSize,
       name: 'Gap Size on Extra Large+',
+      table: { defaultValue: { summary: 'inherited' } },
     },
     gapSizeXxl: {
       ...argTypeGapSize,
       name: 'Gap Size on Extra Extra Large+',
+      table: { defaultValue: { summary: 'inherited' } },
     },
     xPadding: {
-      name: 'Nested Grid',
+      name: 'Padding: x-axis',
+      description: '',
+      table: { defaultValue: { summary: 'false' } },
+      control: {
+        type: 'boolean',
+      },
+    },
+    yPadding: {
+      name: 'Padding: y-axis',
+      description: '',
+      table: { defaultValue: { summary: 'false' } },
       control: {
         type: 'boolean',
       },
     },
     fullBleed: {
-      name: 'Full Bleed Grid',
+      name: 'Full Bleed',
+      description:
+        'If the container should be full bleed and extend its left and right edges to edge of parent.',
+      table: { defaultValue: { summary: 'false' } },
       control: {
         type: 'boolean',
       },
     },
   },
+  args: {
+    xPadding: false,
+    yPadding: false,
+    fullBleed: false,
+  },
 };
 
 interface Options {
-  gapSize?: string;
-  gapSizeSm?: number;
-  gapSizeMd?: number;
-  gapSizeLg?: number;
-  gapSizeXl?: number;
-  gapSizeXxl?: number;
+  gapSize?: Size;
+  gapSizeSm?: Size;
+  gapSizeMd?: Size;
+  gapSizeLg?: Size;
+  gapSizeXl?: Size;
+  gapSizeXxl?: Size;
   xPadding?: boolean;
+  yPadding?: boolean;
   fullBleed?: boolean;
   defaultSlot?: boolean;
 }
@@ -70,6 +97,7 @@ const Template = ({
   gapSizeXl,
   gapSizeXxl,
   xPadding,
+  yPadding,
   fullBleed,
   defaultSlot,
 }: Options): TemplateResult => html`
@@ -80,14 +108,20 @@ const Template = ({
     gap-size-lg="${ifDefined(gapSizeLg)}"
     gap-size-xl="${ifDefined(gapSizeXl)}"
     gap-size-xxl="${ifDefined(gapSizeXxl)}"
-    x-padding="${ifDefined(xPadding)}"
-    full-bleed="${ifDefined(fullBleed)}"
+    ?x-padding="${xPadding}"
+    ?y-padding="${yPadding}"
+    ?full-bleed="${fullBleed}"
   >
     ${defaultSlot}
   </outline-grid>
 `;
 
+const DefaultGridDecorators = [
+  (Story): TemplateResult => html` <div class="block py-12">${Story()}</div> `,
+];
+
 export const RowsAndColumns = Template.bind({});
+RowsAndColumns.decorators = DefaultGridDecorators;
 RowsAndColumns.args = {
   gapSize: 'small',
   defaultSlot: html`
@@ -134,6 +168,7 @@ RowsAndColumns.args = {
 };
 
 export const EqualColumns = Template.bind({});
+EqualColumns.decorators = DefaultGridDecorators;
 EqualColumns.args = {
   gapSize: 'small',
   defaultSlot: html`
@@ -164,13 +199,14 @@ EqualColumns.args = {
 };
 
 export const FullBleed = Template.bind({});
+FullBleed.decorators = DefaultGridDecorators;
 FullBleed.args = {
   gapSize: 'small',
   fullBleed: true,
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        Equal Column Grid</outline-heading
+        Full Bleed Grid</outline-heading
       >
     </outline-column>
     <outline-column
@@ -195,12 +231,13 @@ FullBleed.args = {
 };
 
 export const AsymmetricLeft = Template.bind({});
+AsymmetricLeft.decorators = DefaultGridDecorators;
 AsymmetricLeft.args = {
   gapSize: 'small',
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        >Asymmetrical Grid</outline-heading
+        Asymmetrical Grid</outline-heading
       >
     </outline-column>
     <outline-column
@@ -225,12 +262,13 @@ AsymmetricLeft.args = {
 };
 
 export const AsymmetricRight = Template.bind({});
+AsymmetricRight.decorators = DefaultGridDecorators;
 AsymmetricRight.args = {
   gapSize: 'small',
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        >Asymmetrical Grid</outline-heading
+        Asymmetrical Grid</outline-heading
       >
     </outline-column>
     <outline-column
@@ -255,19 +293,16 @@ AsymmetricRight.args = {
 };
 
 export const AsymmetricLeftWithBorder = Template.bind({});
+AsymmetricLeftWithBorder.decorators = DefaultGridDecorators;
 AsymmetricLeftWithBorder.args = {
   gapSize: '',
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        >Asymmetrical Grid With Divider</outline-heading
+        Asymmetrical Grid With Divider</outline-heading
       >
     </outline-column>
-
     <outline-column col-span-default="12" class="pb-2">
-      <!-- <outline-heading level="h3" level-style="3">
-        Border gap size: small</outline-heading
-      > -->
       <h3>Border gap size: small</h3>
     </outline-column>
 
@@ -303,9 +338,12 @@ AsymmetricLeftWithBorder.args = {
     </outline-column>
 
     <outline-column col-span-default="12" class="pb-2 border-t-2 mt-6 pt-4">
-      <outline-heading level="h3" level-style="semibold">
-        Border gap size: medium</outline-heading
+      <outline-heading level="h2" level-style="semibold">
+        Asymmetrical Grid With Divider</outline-heading
       >
+    </outline-column>
+    <outline-column col-span-default="12" class="pb-2">
+      <h3>Border gap size: medium</h3>
     </outline-column>
 
     <outline-column
@@ -340,10 +378,12 @@ AsymmetricLeftWithBorder.args = {
     </outline-column>
 
     <outline-column col-span-default="12" class="pb-2 border-t-2 mt-6 pt-4">
-      <outline-heading level="h3" level-style="semibold">
-        Border gap size: large</outline-heading
+      <outline-heading level="h2" level-style="semibold">
+        Asymmetrical Grid With Divider</outline-heading
       >
-      -
+    </outline-column>
+    <outline-column col-span-default="12" class="pb-2">
+      <h3>Border gap size: large</h3>
     </outline-column>
 
     <outline-column
@@ -380,11 +420,12 @@ AsymmetricLeftWithBorder.args = {
 };
 
 export const OffsetLeft = Template.bind({});
+OffsetLeft.decorators = DefaultGridDecorators;
 OffsetLeft.args = {
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        >Offset Left</outline-heading
+        Offset Left</outline-heading
       >
     </outline-column>
     <outline-column
@@ -400,11 +441,12 @@ OffsetLeft.args = {
 };
 
 export const OffsetRight = Template.bind({});
+OffsetRight.decorators = DefaultGridDecorators;
 OffsetRight.args = {
   defaultSlot: html`
     <outline-column col-span-default="12">
       <outline-heading level="h2" level-style="semibold">
-        >Offset Right</outline-heading
+        Offset Right</outline-heading
       >
     </outline-column>
     <outline-column

--- a/src/components/base/outline-grid/outline-grid.stories.ts
+++ b/src/components/base/outline-grid/outline-grid.stories.ts
@@ -35,7 +35,7 @@ export default {
       ...argTypeGapSize,
       name: 'Gap Size on Extra Extra Large+',
     },
-    isNested: {
+    xPadding: {
       name: 'Nested Grid',
       control: {
         type: 'boolean',
@@ -57,7 +57,7 @@ interface Options {
   gapSizeLg?: number;
   gapSizeXl?: number;
   gapSizeXxl?: number;
-  isNested?: boolean;
+  xPadding?: boolean;
   fullBleed?: boolean;
   defaultSlot?: boolean;
 }
@@ -69,7 +69,7 @@ const Template = ({
   gapSizeLg,
   gapSizeXl,
   gapSizeXxl,
-  isNested,
+  xPadding,
   fullBleed,
   defaultSlot,
 }: Options): TemplateResult => html`
@@ -80,7 +80,7 @@ const Template = ({
     gap-size-lg="${ifDefined(gapSizeLg)}"
     gap-size-xl="${ifDefined(gapSizeXl)}"
     gap-size-xxl="${ifDefined(gapSizeXxl)}"
-    is-nested="${ifDefined(isNested)}"
+    x-padding="${ifDefined(xPadding)}"
     full-bleed="${ifDefined(fullBleed)}"
   >
     ${defaultSlot}

--- a/src/components/base/outline-grid/outline-grid.ts
+++ b/src/components/base/outline-grid/outline-grid.ts
@@ -8,6 +8,7 @@ import '../outline-container/outline-container';
 /**
  * The Outline Grid component
  * @attr x-padding - passed to outline-container wrapper.
+ * @attr y-padding - passed to outline-container wrapper.
  * @attr full-bleed - passed to outline-container wrapper.
  * @attr container-align - passed to outline-container wrapper.
  * @slot - The default, and only slot for this element.
@@ -101,8 +102,9 @@ export class OutlineGrid extends OutlineElement {
   render(): TemplateResult {
     return html`
       <outline-container
-        x-padding="${ifDefined(this.xPadding)}"
-        full-bleed="${ifDefined(this.fullBleed)}"
+        ?x-padding="${this.xPadding}"
+        ?y-padding="${this.yPadding}"
+        ?full-bleed="${this.fullBleed}"
         container-align="${ifDefined(this.containerAlign)}"
       >
         <slot></slot>

--- a/src/components/base/outline-grid/outline-grid.ts
+++ b/src/components/base/outline-grid/outline-grid.ts
@@ -7,7 +7,7 @@ import type { HorizontalAlignment, Size } from '../outline-element/utils/types';
 import '../outline-container/outline-container';
 /**
  * The Outline Grid component
- * @attr is-nested - passed to outline-container wrapper.
+ * @attr x-padding - passed to outline-container wrapper.
  * @attr full-bleed - passed to outline-container wrapper.
  * @attr container-align - passed to outline-container wrapper.
  * @slot - The default, and only slot for this element.
@@ -17,14 +17,24 @@ export class OutlineGrid extends OutlineElement {
   static styles: CSSResultGroup = [componentStyles];
 
   /**
-   * Whether or not this container has padding.
+   * Whether or not this container has left/right padding.
    */
   @property({
     type: Boolean,
     reflect: true,
-    attribute: 'is-nested',
+    attribute: 'x-padding',
   })
-  isNested = true;
+  xPadding = false;
+
+  /**
+   * Whether or not this container has left/right padding.
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    attribute: 'y-padding',
+  })
+  yPadding = false;
 
   /**
    * Whether or not this is a full bleed container.
@@ -91,7 +101,7 @@ export class OutlineGrid extends OutlineElement {
   render(): TemplateResult {
     return html`
       <outline-container
-        is-nested="${ifDefined(this.isNested)}"
+        x-padding="${ifDefined(this.xPadding)}"
         full-bleed="${ifDefined(this.fullBleed)}"
         container-align="${ifDefined(this.containerAlign)}"
       >

--- a/src/components/base/outline-grid/test/outline-grid.test.ts
+++ b/src/components/base/outline-grid/test/outline-grid.test.ts
@@ -1,5 +1,6 @@
 import { OutlineGrid } from '../outline-grid';
-import { assert, fixture, html } from '@open-wc/testing';
+import { assert, fixture } from '@open-wc/testing';
+import { html } from 'lit/static-html.js';
 
 describe('outline-grid', () => {
   it('is defined', () => {
@@ -12,11 +13,7 @@ describe('outline-grid', () => {
     assert.shadowDom.equal(
       el,
       `
-      <outline-container
-        container-align="center"
-        full-bleed=""
-        x-padding=""
-      >
+      <outline-container container-align="center">
         <slot>
         </slot>
       </outline-container>

--- a/src/components/base/outline-grid/test/outline-grid.test.ts
+++ b/src/components/base/outline-grid/test/outline-grid.test.ts
@@ -15,7 +15,7 @@ describe('outline-grid', () => {
       <outline-container
         container-align="center"
         full-bleed=""
-        is-nested=""
+        x-padding=""
       >
         <slot>
         </slot>

--- a/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.ts
+++ b/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.ts
@@ -389,7 +389,7 @@ export default class OutlineTabGroup extends OutlineElement {
     return html`${
       this.mobileController.isMobile
         ? html`<slot name="accordion-wrapper"></slot> `
-        : html`<outline-container is-nested
+        : html`<outline-container x-padding
             ><div
               part="base"
               class=${classMap({

--- a/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.ts
+++ b/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.ts
@@ -389,7 +389,7 @@ export default class OutlineTabGroup extends OutlineElement {
     return html`${
       this.mobileController.isMobile
         ? html`<slot name="accordion-wrapper"></slot> `
-        : html`<outline-container x-padding
+        : html`<outline-container
             ><div
               part="base"
               class=${classMap({


### PR DESCRIPTION
## Description

- Fix issue with `is-nested` where the value could never be set to false.
- Refactor `is-nested` to be `x-padding` to be more descriptive.
- Feature: add `y-padding`
- Configure these values via CSS Custom Properties. 
- Update the `outline-grid` to properly utilize the new `x-padding` and `y-padding` properties from `outline-container`
- Fix multiple issues with `outline-grid` Storybook stories.
- Fix issues where storybook was unable to properly display the `xxxl` viewport (2160px) causing "oddities" in the display at previous max-width. This was needed to properly test the container/grid at ALL breakpoints.
- Adds additional descriptions and default value labels in container/grid stories.

Creates CSS Variables to handle the spacing for the x/y padding on default containers. Typically we've NOT used the `y-padding`, allowing the content inside a container to handle this, however, I can see reason this could be useful. 

```css
 /* 
  * Configuration values for `outline-container`.
  */
  --outline-container-padding-x: 1.5rem; 
  --outline-container-padding-y: 1.5rem;
```

## Testing

- View `Container`  and `Grid` in storybook and toggle the new padding controls.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/191"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

