### PR TITLE
fix(outline-container): handle booleans

### DIFF
--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -37,54 +37,46 @@
     @apply max-w-screen-xxxl;
   }
 }
-:host([is-nested]),
-:host([is-nested='true']) {
+:host(:not([is-nested])) {
   @apply px-0;
 }
 
-:host([full-bleed='']),
-:host([full-bleed='true']) {
+:host([full-bleed]) {
   @apply max-w-full;
 }
 
 @screen sm {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen md {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen lg {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen xl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]), {
     @apply max-w-full;
   }
 }
 
 @screen xxl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
 
 @screen xxxl {
-  :host([full-bleed='']),
-  :host([full-bleed='true']) {
+  :host([full-bleed]) {
     @apply max-w-full;
   }
 }
@@ -92,7 +84,7 @@
 :host([container-align='left']) {
   @apply ml-0 mr-auto;
 }
-:host([container-align='']),
+:host([container-align]),
 :host([container-align='center']) {
   @apply mx-auto;
 }

--- a/src/components/base/outline-container/outline-container.stories.ts
+++ b/src/components/base/outline-container/outline-container.stories.ts
@@ -46,8 +46,8 @@ export const Container = ({
   html`
     <outline-container
       class="text-left rounded-xl border-2 border-dashed bg-demo-lightBlue border-demo-darkBlue py-10 md:py-20 my-10 md:my-20"
-      is-nested="${ifDefined(isNested)}"
-      full-bleed="${ifDefined(fullBleed)}"
+      ?is-nested="${isNested}"
+      ?full-bleed="${fullBleed}"
       container-align="${ifDefined(containerAlign)}"
     >
       <!-- <outline-heading level="h2" level-size="2xl" class="mb-4"

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -18,6 +18,7 @@ export class OutlineContainer extends OutlineElement {
    */
   @property({
     type: Boolean,
+    reflect: true,
     attribute: 'is-nested',
   })
   isNested = false;


### PR DESCRIPTION
Updates #191 to reflect attribute and update css / story to match.

- Booleans are true if present and false if not.
- The CSS uses the presence of the attribute.
- Reflect is true so that CSS can detect it.

## Testing notes

In Storybook, view the `Container` story.

## Examples

![padding](https://user-images.githubusercontent.com/397902/146413834-0da95b0c-6778-4a94-a6d4-6910442dca09.jpg)

![no-padding](https://user-images.githubusercontent.com/397902/146413897-b1506e18-5849-4e7d-b6e2-7b5689f13b2e.jpg)

## Developer notes

The naming of Storybook with "Padding" and "Is Nested" is confusing, but I updated it so that padding is applied when the control is used in Storybook (when not nested).

Merging this will almost surely cause regressions since this component never worked with the flag before so some sites might get extra padding around things.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

