### PR TITLE
fix: update Gitpod setup with Storybook port 6042

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ vscode:
 
 ports:
   # Used by Storybook
-  - port: 6006
+  - port: 6042
     onOpen: open-preview
 
 github:


### PR DESCRIPTION
https://github.com/phase2/outline/pull/152 changed the port Storybook is using (used to be 6006)

This PR updates Gitpod to open Storybook preview automatically when port 6042 is ready.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/193"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

