### PR TITLE
Storybook Deprecation Cleanup

### DIFF
--- a/src/.storybook/stories/documentation/tooling.stories.mdx
+++ b/src/.storybook/stories/documentation/tooling.stories.mdx
@@ -9,7 +9,7 @@ import webComponentsLogo from '../assets/logos/web-components.png';
 import tailwindLogo from '../assets/logos/tailwind.png';
 import typescriptLogo from '../assets/logos/typescript.png';
 import litLogo from '../assets/logos/lit.png';
-import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 <Meta
   title="Documentation/About Outline"

--- a/src/.storybook/stories/documentation/welcome.stories.mdx
+++ b/src/.storybook/stories/documentation/welcome.stories.mdx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 <Meta
   title="Documentation/Welcome"

--- a/src/.storybook/stories/guides/contributing.stories.mdx
+++ b/src/.storybook/stories/guides/contributing.stories.mdx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 <Meta
   title="Documentation/Guides/Developer/Contributing to Outline"

--- a/src/.storybook/stories/protons/spacing.stories.mdx
+++ b/src/.storybook/stories/protons/spacing.stories.mdx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 import { extractPx } from '../../../components/base/outline-element/utils/utils';
 import tailwindThemeConfig from '../../../resolved-tailwind-config';

--- a/src/.storybook/stories/protons/typefaces.stories.mdx
+++ b/src/.storybook/stories/protons/typefaces.stories.mdx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, Preview } from '@storybook/addon-docs';
 
 <Meta
   title="Design Tokens/Typefaces"

--- a/src/components/base/outline-accordion/outline-accordion.stories.ts
+++ b/src/components/base/outline-accordion/outline-accordion.stories.ts
@@ -66,7 +66,7 @@ export default {
         type: 'boolean',
       },
       name: 'all open',
-      defaultValue: false,
+      table: { defaultValue: { summary: 'false' } },
     },
     singlePanel: {
       description:
@@ -125,6 +125,7 @@ export default {
 </outline-accordion-panel>`,
     clean: false,
     singlePanel: false,
+    allOpen: true,
   },
 };
 

--- a/src/components/base/outline-button/outline-button.stories.ts
+++ b/src/components/base/outline-button/outline-button.stories.ts
@@ -38,23 +38,23 @@ export default {
     variant: {
       description:
         '**ButtonVariant (none, primary, secondary, teritary)**: The button style variant to use.',
+      options: buttonOptions,
       control: {
         type: 'select',
-        options: buttonOptions,
       },
     },
     size: {
       description:
         '**ButtonSize (small, medium, large)** The button size to use',
+      options: sizeOptions,
       control: {
         type: 'select',
-        options: sizeOptions,
       },
     },
     // icon: {
+    //   options: AllIcons,
     //   control: {
     //     type: 'select',
-    //     options: AllIcons,
     //   },
     // },
   },
@@ -122,14 +122,14 @@ Link.args = {
   size: 'medium',
 };
 
-export const IconLink = Template.bind({});
-IconLink.args = {
-  defaultSlot: 'Link button w/icon',
-  size: 'medium',
-  url: '#',
-  variant: 'primary',
-  icon: 'arrowNarrowRightOutline',
-};
+// export const IconLink = Template.bind({});
+// IconLink.args = {
+//   defaultSlot: 'Link button w/icon',
+//   size: 'medium',
+//   url: '#',
+//   variant: 'primary',
+//   icon: 'arrowNarrowRightOutline',
+// };
 
 export const PrimaryButton = Template.bind({});
 PrimaryButton.args = {

--- a/src/components/base/outline-card/outline-card.stories.ts
+++ b/src/components/base/outline-card/outline-card.stories.ts
@@ -18,9 +18,9 @@ const allowedColors: string[] = [
 
 const argTypeColors = {
   name: 'Color',
+  options: allowedColors,
   control: {
     type: 'select',
-    options: allowedColors,
   },
 };
 

--- a/src/components/base/outline-container/outline-container.stories.ts
+++ b/src/components/base/outline-container/outline-container.stories.ts
@@ -15,7 +15,7 @@ export default {
     containerAlign: {
       ...argTypeHorizontalAlign,
       name: 'Alignment of the Container',
-      defaultValue: 'center',
+      table: { defaultValue: { summary: 'center' } },
     },
     isNested: {
       name: 'Padding',
@@ -29,6 +29,9 @@ export default {
         type: 'boolean',
       },
     },
+  },
+  args: {
+    containerAlign: 'center',
   },
 };
 

--- a/src/components/base/outline-grid/outline-column/outline-column.stories.ts
+++ b/src/components/base/outline-grid/outline-column/outline-column.stories.ts
@@ -22,7 +22,7 @@ export default {
     colSpanDefault: {
       ...argTypeColSpan,
       name: 'Default Number of Columns to Span',
-      defaultValue: 12,
+      table: { defaultValue: { summary: '12' } },
     },
     colSpanSm: {
       ...argTypeColSpan,
@@ -47,18 +47,23 @@ export default {
     rowSpan: {
       ...argTypeRowSpan,
       name: 'Number of Rows to Span',
-      defaultValue: 1,
+      table: { defaultValue: { summary: '1' } },
     },
     numContentCols: {
       ...argTypeColSpan,
       name: 'Number of Content Blocks',
       description: 'The number of blocks to place for this demo.',
-      defaultValue: 12,
+      table: { defaultValue: { summary: '12' } },
     },
     contentAlign: {
       ...argTypeVerticalAlign,
       name: 'Column Content Vertical Alignment',
     },
+  },
+  args: {
+    colSpanDefault: 12,
+    rowSpan: 1,
+    numContentCols: 12,
   },
   decorators: [
     Story => html`

--- a/src/components/base/outline-heading/outline-heading.stories.ts
+++ b/src/components/base/outline-heading/outline-heading.stories.ts
@@ -23,23 +23,23 @@ export default {
     ...argTypeSlotContent,
     level: {
       description: 'HTML level. Used by screen readers.',
+      options: levelOptions,
       control: {
         type: 'select',
-        options: levelOptions,
       },
     },
     levelSize: {
       description: 'Presentation level. Used for styling.',
+      options: HeadingSizes,
       control: {
         type: 'select',
-        options: HeadingSizes,
       },
     },
     levelStyle: {
       description: 'Presentation style. Font weight variation.',
+      options: HeadingStyles,
       control: {
         type: 'select',
-        options: HeadingStyles,
       },
     },
   },

--- a/src/components/base/outline-icon/outline-icon.stories.mdx
+++ b/src/components/base/outline-icon/outline-icon.stories.mdx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { iconList, brand, custom, outline, solid } from './iconList';
 import './outline-icon';
 import '../../utility/sb-icon-wrapper/sb-icon-wrapper';

--- a/src/components/base/outline-link/config.ts
+++ b/src/components/base/outline-link/config.ts
@@ -33,31 +33,31 @@ export const argTypeTarget = {
   name: 'Link Target',
   description:
     '**LinkTargetType(_blank, _self, _parent, _top):** https://www.w3schools.com/tags/att_a_target.asp',
+  options: ['_blank', '_self', '_parent', '_top'],
   control: {
     type: 'select',
-    options: ['_blank', '_self', '_parent', '_top'],
   },
 };
 
 export const argTypeRel = {
   name: 'Link Relationship',
   description: 'https://www.w3schools.com/tags/att_a_rel.asp',
+  options: [
+    'alternate',
+    'author',
+    'bookmark',
+    'external',
+    'help',
+    'license',
+    'next',
+    'nofollow',
+    'noopener',
+    'noreferrer',
+    'prev',
+    'search',
+    'tag',
+  ],
   control: {
     type: 'select',
-    options: [
-      'alternate',
-      'author',
-      'bookmark',
-      'external',
-      'help',
-      'license',
-      'next',
-      'nofollow',
-      'noopener',
-      'noreferrer',
-      'prev',
-      'search',
-      'tag',
-    ],
   },
 };

--- a/src/components/base/outline-list/outline-list.stories.ts
+++ b/src/components/base/outline-list/outline-list.stories.ts
@@ -62,16 +62,17 @@ export default {
     listType: {
       description:
         '**`<ListType>`("ol" | "ul" | "div"):** <br> Determines which type of list is rendered.',
+      options: listTypes,
       control: {
         type: 'select',
-        options: listTypes,
       },
       name: 'list-type',
     },
     orientation: {
       description:
         '**`<ListOrientation>`("row" | "column"):** <br> Sets orientation of list',
-      control: { type: 'select', options: listOrientations },
+      options: listOrientations,
+      control: { type: 'select' },
     },
     navLabel: {
       description:
@@ -82,17 +83,17 @@ export default {
     columns: {
       description:
         '**`<ColumnCount>`("2", "3", "4"):** <br> If set, overrides orientation setting and renders list above mobile in selected number of columns',
+      options: [...columnsCount, undefined],
       control: {
         type: 'select',
-        options: [...columnsCount, undefined],
       },
     },
     divider: {
       description:
         '**`<ListDividerColors>` ("orange","green","blue","teal","purple","white"):** <br>If set adds a pseudo element divider of chose color between all list items. Currently only setup for `<ul/>`. Best only for row.',
+      options: [...dividerColors, undefined],
       control: {
         type: 'select',
-        options: [...dividerColors, undefined],
       },
     },
     headingSlotContent: {

--- a/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.stories.ts
+++ b/src/components/base/outline-tabs/outline-tab-group/outline-tab-group.stories.ts
@@ -60,9 +60,9 @@ export default {
   argTypes: {
     placement: {
       name: 'Control Placement',
+      options: tabControlPosition,
       control: {
         type: 'select',
-        options: tabControlPosition,
       },
       description: 'The placement of the tab controls.',
     },


### PR DESCRIPTION
Fixing a list of issues preventing any upgrade to Storybook 7.0. 
This just reduces the warnings in the console as well as prepare all our stories to be built correctly. 

See:

- https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-controloptions
- https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args
- https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-scoped-blocks-imports

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

