### PR TITLE
[DRAFT] fix: adds return to setactive for if there is no id on the target

### DIFF
--- a/src/components/base/outline-accordion/outline-accordion.ts
+++ b/src/components/base/outline-accordion/outline-accordion.ts
@@ -82,6 +82,8 @@ export class OutlineAccordion extends OutlineElement {
     const element = e?.target as HTMLElement;
     const contentId = element.id;
 
+    if (!contentId) return;
+
     // if single-panel = true
 
     if (this.singlePanel) {


### PR DESCRIPTION
* Currently if the accordion is set to `single-panel = true` then you are able to click on the panel itself to close it, which is not desired behavior. For instance if there is something in that panel that you are wanting to interact with then it will close the panel.

* This behavior is happening because the setActive click handler is running the close logic even when the target element has no id, such as in the case when you click on the panel itself. 
* This PR adds a return if there is not id on the element, preventing the unwanted behavior. This still works as desired when clicking on the heading to close the panel.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/198"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

