### PR TITLE
Make default video configurable

### DIFF
--- a/outline.config.js
+++ b/outline.config.js
@@ -18,4 +18,9 @@ module.exports = {
   color: {
     sets: ['primary', 'secondary', 'tertiary', 'neutral', 'demo'],
   },
+  youtube: {
+    // Replace with the YouTube id of any video to replace the
+    // default video in any storybook component.
+    defaultVideo: 'xiqgG8HUZXE',
+  },
 };

--- a/src/components/base/outline-video-youtube/outline-video-youtube.stories.ts
+++ b/src/components/base/outline-video-youtube/outline-video-youtube.stories.ts
@@ -1,6 +1,7 @@
 import { html, TemplateResult } from 'lit';
 import './outline-video-youtube';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import outline from '../../../../outline.config';
 
 const configuration = {
   title: 'Media/Youtube Video',
@@ -13,13 +14,15 @@ const configuration = {
     },
   },
   args: {
-    videoID: `xiqgG8HUZXE`,
+    videoID: outline.youtube.defaultVideo
+      ? outline.youtube.defaultVideo
+      : 'xiqgG8HUZXE',
   },
   parameters: {
     docs: {
       description: {
         component: `
-Youtube video. Allows the embedded video to fit the space.
+Responsive Youtube video.
 `,
       },
       source: {


### PR DESCRIPTION
This adds the ability in `outline-video-youtube` to declare a default video for Storybook to display via `outline.config.js`. 

`outline.config.js`
```js
module.exports = {
  youtube: {
    // Replace with the YouTube id of any video to replace the
    // default video in any storybook component.
    defaultVideo: 'xiqgG8HUZXE',
  },
};

```

Then a simple `videoID: outline.youtube.defaultVideo ? outline.youtube.defaultVideo : 'xiqgG8HUZXE'`, in the Storybook story enables sites to utilize this component as is by simply changing the default demo video to be client specific. 

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

