### PR TITLE
feat(prettier): remove all Storybook stories from Prettier processing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,8 @@ docs/
 .gitlab-ci/*
 *.lit.ts
 *.stories.mdx
+*.stories.ts
+*.stories.js
 .github/
 .octane-ci/
 .bin/


### PR DESCRIPTION
This allows for proper formatting of things wrapped in a template literal. 
We've already turned it off for MDX stories, this just ensures all Storybook files are able to be formatted as needed for proper display. 

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/202"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

