### PR TITLE
fix(css): fix for missing box-model on components

### DIFF
--- a/scripts/styles.js
+++ b/scripts/styles.js
@@ -87,6 +87,17 @@ const createCssLiterals = filepath => {
           `
 import { css } from 'lit';
 export default css\`
+:host {
+  box-sizing: border-box;
+}
+:host *,
+:host *::before,
+:host *::after {
+  box-sizing: inherit;
+}
+[hidden] {
+  display: none !important;
+}
 ${result.css}\`;`,
           () => true
         );

--- a/scripts/styles.js
+++ b/scripts/styles.js
@@ -87,6 +87,7 @@ const createCssLiterals = filepath => {
           `
 import { css } from 'lit';
 export default css\`
+/* Apply standardized box sizing to the component. */
 :host {
   box-sizing: border-box;
 }
@@ -98,6 +99,7 @@ export default css\`
 [hidden] {
   display: none !important;
 }
+/* Apply component specific CSS */
 ${result.css}\`;`,
           () => true
         );


### PR DESCRIPTION
Updates the `createCssLiterals` function in `scripts/style.js` to include basic box sizing to apply to every component. This fixes inconsistencies seen between the LightDOM and ShadowDOM.

```javascript
/**
 * Function to wrap all generic .css files with CSS template literals suitable for consumption via Lit.
 *
 * @param {string} filepath
 */
const createCssLiterals = filepath => {
  const filename = filepath.replace(/^.*[\\\/]/, '');
  fs.readFile(filepath, (err, css) => {
    const nFilePath = `${filepath}.lit.ts`;
    postcss([...config.plugins])
      .process(css, { from: filepath, to: nFilePath })
      .then(result => {
        fs.writeFile(
          nFilePath,
          `
import { css } from 'lit';
export default css\`
/* Apply standardized box sizing to the component. */
:host {
  box-sizing: border-box;
}
:host *,
:host *::before,
:host *::after {
  box-sizing: inherit;
}
[hidden] {
  display: none !important;
}
/* Apply component specific CSS */
${result.css}\`;`,
          () => true
        );
      });
  });
};
```

> NOTE: This is marked as a `Breaking Change` only as this could negatively impact existing CSS styles on some components where these styles would be applied.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/204"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

