### PR TITLE
fix(cleanup): removing unused code from outline-element

### DIFF
--- a/src/components/base/outline-element/outline-element.ts
+++ b/src/components/base/outline-element/outline-element.ts
@@ -1,43 +1,12 @@
 import { LitElement, TemplateResult } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { queryAll, queryAssignedNodes, customElement } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 //import componentStyles from './outline-element.base.css.lit';
 
 @customElement('outline-element')
 export class OutlineElement extends LitElement {
   //static styles: CSSResultGroup = [componentStyles];
-
-  // Get all slots on an element.
-  @queryAll('slot')
-  _slots: NodeListOf<HTMLElement>;
-
-  // get this._slots.forEach((slot) => {
-
-  // });
-  // Get all nodes inside the header slot.
-  // @queryAssignedNodes('header')
-  // _headerNodes: NodeListOf<HTMLElement>;
-
-  // Get all the nodes inside of the default (unnamed) slot.
-  @queryAssignedNodes()
-  _defaultSlotNodes: NodeListOf<HTMLElement>;
-
-  // private _shadowShim() {
-  //   const slotContent;
-  //   return slotContent: NodeListOf<HTMLElement>
-  // }
-
-  // get _slottedChildren() {
-  //   const slot = this.shadowRoot.querySelector('slot');
-  //   const childNodes = slot.assignedNodes({flatten: true});
-  //   return Array.prototype.filter.call(childNodes, (node) => node.nodeType == Node.ELEMENT_NODE);
-  // }
-
-  // Empty render function. Cool.
-  // render(): TemplateResult {
-  //   return html``;
-  // }
 
   /**
    * Create a conditional slot.


### PR DESCRIPTION
Unused legacy code originally in place for random tests. None of this is being utilized in the core platform, and needs to be cleaned up. 

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

