### PR TITLE
fix(wca): Optimize scanning with wca.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prep": "yarn generate.safelist && yarn generate.resolved-tailwind && yarn generate.custom-elements && yarn generate.css",
     "generate.resolved-tailwind": "node scripts/resolve-tailwind-config.js",
     "generate.safelist": "node scripts/generate-tw-safelist.js",
-    "generate.custom-elements": "wca analyze 'src/components/**/*.ts' --format json --outFile ./src/custom-elements.json",
+    "generate.custom-elements": "wca analyze 'src/components/**/!(*.stories|*.lit|*.test).ts' --format json --outFile ./src/custom-elements.json",
     "generate.css": "node scripts/styles.js",
     "generate.icons": "yarn run fmt.svg && node ./scripts/generate-icons.js ",
     "prebuild": "yarn prep",


### PR DESCRIPTION
Optimizes the glob for `wca` to be more targeted. Current component scanning reduced from 70 files to 41.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

