### PR TITLE
fix: add rule to prevent console messages to be committed

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,6 @@
 {
   "*.{ts,tsx,js}": [
-    "eslint --fix",
+    "eslint --rule 'no-console: error' --fix",
     "prettier --write"
   ],
   "*.{json,md}": [


### PR DESCRIPTION
Adds the eslint rule to not allow `console` messages when committing. This prevents the back and forth in PR review "did you mean to leave this `console.log` here?"

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

![image](https://user-images.githubusercontent.com/1178060/153225052-2ee10e81-b6aa-4fef-8036-1b55d9aa6f37.png)
