### PR TITLE
Make Storybook port public by default

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,7 @@ ports:
   # Used by Storybook
   - port: 6042
     onOpen: open-preview
+    visibility: public
 
 github:
   prebuilds:


### PR DESCRIPTION
When running Gitpod instance, the generated Storybook should be shareable (public port) by default.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

