### PR TITLE
Adding global interface declarations to all components

### DIFF
--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
@@ -84,3 +84,9 @@ export class OutlineAccordionPanel extends OutlineElement {
     </div>`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-accordion-panel': OutlineAccordionPanel;
+  }
+}

--- a/src/components/base/outline-accordion/outline-accordion.ts
+++ b/src/components/base/outline-accordion/outline-accordion.ts
@@ -168,3 +168,9 @@ export class OutlineAccordion extends OutlineElement {
     }
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-accordion': OutlineAccordion;
+  }
+}

--- a/src/components/base/outline-admin-links/outline-admin-links.ts
+++ b/src/components/base/outline-admin-links/outline-admin-links.ts
@@ -26,3 +26,9 @@ export class OutlineAdminLinks extends OutlineElement {
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-admin-links': OutlineAdminLinks;
+  }
+}

--- a/src/components/base/outline-alert/outline-alert.ts
+++ b/src/components/base/outline-alert/outline-alert.ts
@@ -80,3 +80,9 @@ export class OutlineAlert
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-alert': OutlineAlert;
+  }
+}

--- a/src/components/base/outline-breadcrumbs/outline-breadcrumbs.ts
+++ b/src/components/base/outline-breadcrumbs/outline-breadcrumbs.ts
@@ -46,3 +46,9 @@ export class OutlineBreadcrumbs extends OutlineElement {
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-breadcrumbs': OutlineBreadcrumbs;
+  }
+}

--- a/src/components/base/outline-button/outline-button.ts
+++ b/src/components/base/outline-button/outline-button.ts
@@ -110,3 +110,9 @@ export class OutlineButton extends OutlineElement {
     }
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-button': OutlineButton;
+  }
+}

--- a/src/components/base/outline-card/outline-card.ts
+++ b/src/components/base/outline-card/outline-card.ts
@@ -108,3 +108,9 @@ export class OutlineCard extends OutlineElement {
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-card': OutlineCard;
+  }
+}

--- a/src/components/base/outline-code-block/outline-code-block.ts
+++ b/src/components/base/outline-code-block/outline-code-block.ts
@@ -131,3 +131,9 @@ export class OutlineCodeBlock extends OutlineElement {
     return prismCode;
   };
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-code-block': OutlineCodeBlock;
+  }
+}

--- a/src/components/base/outline-container/outline-container.ts
+++ b/src/components/base/outline-container/outline-container.ts
@@ -60,3 +60,9 @@ export class OutlineContainer extends OutlineElement {
     return html`<slot></slot>`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-container': OutlineContainer;
+  }
+}

--- a/src/components/base/outline-element/outline-element.ts
+++ b/src/components/base/outline-element/outline-element.ts
@@ -50,3 +50,9 @@ export class OutlineElement extends LitElement {
       : null;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-element': OutlineElement;
+  }
+}

--- a/src/components/base/outline-grid/outline-grid.ts
+++ b/src/components/base/outline-grid/outline-grid.ts
@@ -112,3 +112,9 @@ export class OutlineGrid extends OutlineElement {
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-grid': OutlineGrid;
+  }
+}

--- a/src/components/base/outline-heading/outline-heading.ts
+++ b/src/components/base/outline-heading/outline-heading.ts
@@ -50,3 +50,9 @@ export class OutlineHeading extends OutlineElement {
       </${unsafeStatic(this.level as string)}>`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-heading': OutlineHeading;
+  }
+}

--- a/src/components/base/outline-image-slider/outline-image-slider.ts
+++ b/src/components/base/outline-image-slider/outline-image-slider.ts
@@ -93,3 +93,9 @@ export class OutlineImageSlider extends OutlineElement {
     this.requestUpdate();
   };
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-image-slider': OutlineImageSlider;
+  }
+}

--- a/src/components/base/outline-image/outline-image.ts
+++ b/src/components/base/outline-image/outline-image.ts
@@ -34,3 +34,9 @@ export class OutlineImage extends OutlineElement {
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-image': OutlineImage;
+  }
+}

--- a/src/components/base/outline-link/outline-link.ts
+++ b/src/components/base/outline-link/outline-link.ts
@@ -57,3 +57,9 @@ export class OutlineLink extends OutlineElement {
       : html`<slot></slot>`}`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-link': OutlineLink;
+  }
+}

--- a/src/components/base/outline-list/outline-list.ts
+++ b/src/components/base/outline-list/outline-list.ts
@@ -121,3 +121,9 @@ export class OutlineList extends OutlineElement {
     }
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-list': OutlineList;
+  }
+}

--- a/src/components/base/outline-modal/outline-modal.ts
+++ b/src/components/base/outline-modal/outline-modal.ts
@@ -280,3 +280,9 @@ export class OutlineModal
     return Array.from(focusableSlottedElements).slice(-1)[0] ?? null;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-modal': OutlineModal;
+  }
+}

--- a/src/components/base/outline-svg/outline-svg.ts
+++ b/src/components/base/outline-svg/outline-svg.ts
@@ -70,3 +70,9 @@ export class OutlineSvg extends OutlineElement {
     return html` <div style=${styleMap(styles)}>${iconList[this.name]}</div> `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-svg': OutlineSvg;
+  }
+}

--- a/src/components/base/outline-swatch-set/outline-swatch-set.ts
+++ b/src/components/base/outline-swatch-set/outline-swatch-set.ts
@@ -51,3 +51,9 @@ export class OutlineSwatchSet
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-swatch-set': OutlineSwatchSet;
+  }
+}

--- a/src/components/base/outline-swatch/outline-swatch.ts
+++ b/src/components/base/outline-swatch/outline-swatch.ts
@@ -53,3 +53,9 @@ export class OutlineSwatch
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-swatch': OutlineSwatch;
+  }
+}

--- a/src/components/base/outline-video-vimeo/outline-video-vimeo.ts
+++ b/src/components/base/outline-video-vimeo/outline-video-vimeo.ts
@@ -35,3 +35,9 @@ export class OutlineVideoVimeo
     `;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-video-vimeo': OutlineVideoVimeo;
+  }
+}

--- a/src/components/base/outline-video-youtube/outline-video-youtube.ts
+++ b/src/components/base/outline-video-youtube/outline-video-youtube.ts
@@ -34,3 +34,8 @@ export class OutlineVideoYoutube
     `;
   }
 }
+declare global {
+  interface HTMLElementTagNameMap {
+    'outline-video-youtube': OutlineVideoYoutube;
+  }
+}


### PR DESCRIPTION
> No, this declaration is not necessary for your LitElement based custom element to work.

> This declaration helps TypeScript to provide strong typing when interacting with DOM APIs. The JavaScript DOM API of course does not know or care about types, but TypeScript does. With this mechanism you can add the type of your custom elements to the DOM APIs.

from: https://stackoverflow.com/questions/65148695/lit-element-typescript-project-global-interface-declaration-necessary/65356510#65356510

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/248"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

