### PR TITLE
Updated Rollup and loader configurations

### DIFF
--- a/outline.config.js
+++ b/outline.config.js
@@ -5,6 +5,12 @@
 const destBasePath = 'dist';
 module.exports = {
   destBasePath,
+  components: {
+    // This should include an array of directories under
+    // src/components/ that contain component files.
+    // Currently used only in `js.output.lazy` mode.
+    bundle: ['outline'],
+  },
   css: {
     global: [
       {
@@ -19,6 +25,18 @@ module.exports = {
     fouc: {
       enabled: true,
       dest: `${destBasePath}/fouc.css`,
+    },
+  },
+  js: {
+    output: {
+      // @see src/outline-lazy.ts
+      lazy: false,
+      // @see src/outline-dynamic.ts
+      dynamic: false,
+      // Export full library to `outline.js`.
+      full: true,
+      // @see src/data.ts
+      data: false,
     },
   },
   color: {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@commitlint/cli": "^13.2.0",
     "@commitlint/config-conventional": "^13.2.0",
     "@open-wc/testing": "^3.0.0-next.2",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-replace": "^2.4.2",
     "@storybook/addon-a11y": "^6.4.19",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,31 +5,10 @@ import replace from '@rollup/plugin-replace';
 import multi from '@rollup/plugin-multi-entry';
 import typescript from 'rollup-plugin-typescript2';
 import svg from 'rollup-plugin-svg';
+import json from '@rollup/plugin-json';
 const outline = require('./outline.config');
 
-export default {
-  // Output all components to a single exported file.
-  input: {
-    include: ['src/components/**/*.ts'],
-    exclude: [
-      'src/components/**/*.stories.ts',
-      'src/components/**/*.css.lit.ts',
-      'src/components/**/*.test.ts',
-      'src/components/examples/**/*',
-    ],
-  },
-  output: [
-    {
-      // Modern bundle.
-      file: `${outline.destBasePath}/outline.js`,
-      format: 'esm',
-    },
-    // {
-    //   // Legacy bundle.
-    //   file: `{$outline.destBasePath}/outline-legacy.js`,
-    //   format: 'cjs',
-    // },
-  ],
+const sharedConfig = {
   onwarn(warning) {
     if (warning.code !== 'THIS_IS_UNDEFINED') {
       console.error(`(!) ${warning.message}`);
@@ -39,6 +18,7 @@ export default {
     replace({ 'Reflect.decorate': 'undefined', 'preventAssignment': true }),
     resolve(),
     typescript(),
+    json(),
     terser({
       ecma: 2020,
       module: true,
@@ -54,3 +34,73 @@ export default {
     svg(),
   ],
 };
+
+const outputs = [];
+
+const defaultOutput = {
+  // Output all components to a single exported file.
+  input: {
+    include: ['src/components/**/*.ts'],
+    exclude: [
+      'src/components/**/*.stories.ts',
+      'src/components/**/*.css.lit.ts',
+      'src/components/**/*.test.ts',
+      'src/components/examples/**/*',
+      'src/components/utility/**/*',
+    ],
+  },
+  output: [
+    {
+      // file: `${outline.destBasePath}/outline.js`,
+      file: `${outline.destBasePath}/outline.js`,
+      format: 'esm',
+    },
+  ],
+  ...sharedConfig,
+};
+
+const lazyOutput = {
+  input: {
+    include: ['src/outline-lazy.ts'],
+  },
+  output: [
+    {
+      file: `${outline.destBasePath}/outline-lazy.js`,
+      format: 'esm',
+    },
+  ],
+  ...sharedConfig,
+};
+
+const dynamicOutput = {
+  input: {
+    include: ['src/outline-dynamic.ts'],
+  },
+  output: [
+    {
+      file: `${outline.destBasePath}/outline-dynamic.js`,
+      format: 'esm',
+    },
+  ],
+  ...sharedConfig,
+};
+
+const dataOutput = {
+  input: {
+    include: ['src/data.ts'],
+  },
+  output: [
+    {
+      file: `${outline.destBasePath}/data.js`,
+      format: 'esm',
+    },
+  ],
+  ...sharedConfig,
+};
+
+outline.js.output.full ? outputs.push(defaultOutput) : null;
+outline.js.output.lazy ? outputs.push(lazyOutput) : null;
+outline.js.output.dynamic ? outputs.push(dynamicOutput) : null;
+outline.js.output.data ? outputs.push(dataOutput) : null;
+
+export default outputs;

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,4 @@
+/**
+ * @file src/data.ts
+ * This file should contain various sample data and shared functions.
+ */

--- a/src/outline-dynamic.ts
+++ b/src/outline-dynamic.ts
@@ -1,0 +1,35 @@
+//import outline from './resolved-outline-config';
+import customElements from './component-list.json';
+import {
+  outlineComponentSelector,
+  // outlineComponents,
+  // @ts-expect-error - whatever
+} from '../dist/outline-components.js';
+// import { ReactiveElement } from 'lit';
+
+// keep a record of the components we've loaded in this way
+const imported: String[] = [];
+
+const dynamicLoader = (entry: Element) => {
+  const name = entry.nodeName.toLowerCase();
+  const element = customElements.tags.filter(obj => {
+    return obj.name === name;
+  });
+
+  const importPath = element[0].path;
+
+  const componentPath = importPath.replace('.ts', '.js').replace('./', '');
+
+  if (!imported.includes(name)) {
+    // Dynamic import.
+    import(`../dist/${componentPath}`);
+    // Keep a note of which WCs have been loaded so if we have multiple
+    // instances we don't import twice
+    imported.push(name);
+  }
+};
+
+const elements = document.querySelectorAll(outlineComponentSelector);
+elements.forEach(el => {
+  dynamicLoader(el);
+});

--- a/src/outline-lazy.ts
+++ b/src/outline-lazy.ts
@@ -1,0 +1,67 @@
+import outline from './resolved-outline-config';
+import customElements from './component-list.json';
+
+// keep a record of the components we've loaded in this way
+const imported = {};
+// Set up our observer:
+const observer = new IntersectionObserver((entries, observerRef) => {
+  // The callback is run when the visibility of one or more of the elements
+  // being observed has changed. It's also called on page load.
+
+  entries.forEach(async entry => {
+    //`isIntersecting` will be `true` if any part of the element is currently visible
+    if (entry.isIntersecting) {
+      // We are assuming here that your Web Component is located in a file
+      // named after it's tag name
+      const name = entry.target.nodeName.toLowerCase();
+      // @ts-expect-error - manually added property
+      const componentPath = entry.target.outlinePath
+        .replace('.ts', '.js')
+        .replace('./', '');
+
+      // Once we've observed this element come into view, we can safely remove
+      // the observer since we won't need to import the WC code again
+      observerRef.unobserve(entry.target);
+      if (!imported[name]) {
+        // Keep a note of which WCs have been loaded so if we have multiple
+        // instances we don't import twice
+        imported[name] = true;
+        // Dynamic import.
+        const importPath = `../dist/${componentPath}`;
+        import(importPath);
+      }
+    }
+  });
+});
+
+// Observe all components with the desired class
+let selector = '';
+customElements.tags.forEach((tag, index) => {
+  selector += `${tag.name}${
+    index !== customElements.tags.length - 1 ? ', ' : ''
+  }`;
+});
+const elements = document.querySelectorAll(selector);
+const components = [];
+
+elements.forEach((el, i) => {
+  const tagName = el.tagName.toLowerCase();
+  outline.components.bundle.forEach(bundle => {
+    const element = customElements.tags.filter(obj => {
+      return obj.name === tagName;
+    });
+    //console.log(element[0].path)
+
+    if (tagName.indexOf(`${bundle}-`) == 0) {
+      // @ts-expect-error - manually added property
+      elements[i].outlineBundle = bundle == 'outline' ? 'base' : bundle;
+      // @ts-expect-error - manually added property
+      elements[i].outlinePath = element[0].path;
+      // console.log(elements[i])
+      components.push(elements[i]);
+    }
+  });
+});
+components.forEach(el => {
+  observer.observe(el);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "jsxFactory": "h",
     "useDefineForClassFields": false,
     "strictPropertyInitialization": false,
+    "resolveJsonModule": true,
     "plugins": [
       {
         "name": "ts-lit-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,6 +1962,13 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-multi-entry@^4.0.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-multi-entry/-/plugin-multi-entry-4.1.0.tgz#e531511d4a9f490f766dbee1f10d6d94d26b3863"
@@ -2007,7 +2014,7 @@
   resolved "https://registry.yarnpkg.com/@rollup/plugin-virtual/-/plugin-virtual-2.1.0.tgz#a77bfd0dff74f0203401c75287ff4d1a1cfbc816"
   integrity sha512-CPPAtlKT53HFqC8jFHb/V5WErpU8Hrq2TyCR0A7kPQMlF2wNUf0o1xuAc+Qxj8NCZM0Z3Yvl+FbUXfJjVWqDwA==
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==


### PR DESCRIPTION
## Overview

`outline.config.js` now includes the following:

```js
js: {
  output: {
    // @see src/outline-lazy.ts
    lazy: false,
    // @see src/outline-dynamic.ts
    dynamic: false,
    // Export full library to `outline.js`.
    full: true,
    // @see src/data.ts
    data: false,
  },
},
```

* The `full` option should really always be set to `true`. This is what creates our `outline.js` file to `dist`. 
* The `lazy` option enables the compilation of `src/outline-lazy.ts` to enable lazy loading.
* The `dynamic` option enables the compilation of `src/outline-dynamic.ts` to enable dynaic loading.
* The `data` option enables the compilation of `src/data.ts` to allow external consumer to inherit sample data where appropriate. 

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

## Status

The lazy loading and dynamic loading features should be considered **experimental**. They have not been tested in a production environment. 