### PR TITLE
fix(prettier): Ignore outline.theme.css to allow for intentional formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,4 @@ docs/
 .octane-ci/
 .bin/
 .docksal/
+outline.theme.css


### PR DESCRIPTION
## Description

Ignore `outline.theme.css` to allow for intentional formatting. As more CSS Variable names are being created in other work like #261, this is needed to ensure it doesn't put goofy styling on what should be single line CSS rules. 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ensure Prettier doesn't reformat `outline.theme.css` if there's a really long line. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/270"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

