### PR TITLE
Force GitPod to use node version defined in .nvmrc.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,3 +2,9 @@ FROM gitpod/workspace-node
 
 # Install custom tools, runtime, etc.
 RUN npx playwright install-deps
+
+# Ensure we are on desired version of Node defined in our .nvmrc.
+# For now this is hard coded for simplicity. In the future we will
+# want to make this more flexible and use an environment variable.
+RUN nvm install 16
+RUN nvm use

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,9 +2,3 @@ FROM gitpod/workspace-node
 
 # Install custom tools, runtime, etc.
 RUN npx playwright install-deps
-
-# Ensure we are on desired version of Node defined in our .nvmrc.
-# For now this is hard coded for simplicity. In the future we will
-# want to make this more flexible and use an environment variable.
-RUN nvm install 16
-RUN nvm use

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@ image:
 tasks:
   - init: |
       yarn
+      nvm install $(cat .nvmrc)
+      nvm use
     command: |
       yarn start
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   ],
   "dependencies": {
     "@splidejs/splide": "^3.2.1",
-    "lit": "^2.0.0"
+    "lit": "^2.0.0",
+    "postcss-nested": "^5.0.6"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
   ],
   "dependencies": {
     "@splidejs/splide": "^3.2.1",
-    "lit": "^2.0.0",
-    "postcss-nested": "^5.0.6"
+    "lit": "^2.0.0"
   },
   "engines": {
     "node": ">=14"
@@ -143,6 +142,7 @@
     "postcss-discard-comments": "^5.1.0",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^5.2.0",
+    "postcss-nested": "^5.0.6",
     "postcss-preset-env": "^7.0.0",
     "prettier": "^2.0.4",
     "prettier-plugin-tailwindcss": "^0.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12279,7 +12279,7 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
-postcss-nested@5.0.6:
+postcss-nested@5.0.6, postcss-nested@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-5.0.6.tgz#466343f7fc8d3d46af3e7dba3fcd47d052a945bc"
   integrity sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==


### PR DESCRIPTION
## Description

Ensures the .gitpod.Dockerfile sets up the version of node we would like to use.

```yaml
tasks:
  - init: |
      yarn
      nvm install $(cat .nvmrc)
      nvm use
    command: |
      yarn start
```

Fixes #272

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

![image](https://user-images.githubusercontent.com/21905/161285487-8f8656b2-af0d-460e-9b5f-8fd2e062d755.png)

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/273"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

