### PR TITLE
Issue #167: Adds tests to `outline-admin-links`

### DIFF
--- a/src/components/base/outline-admin-links/test/outline-admin-links.test.ts
+++ b/src/components/base/outline-admin-links/test/outline-admin-links.test.ts
@@ -1,0 +1,47 @@
+import { OutlineAdminLinks } from '../outline-admin-links';
+import { assert, fixture, elementUpdated } from '@open-wc/testing';
+import { html } from 'lit/static-html.js';
+
+describe('outline-admin-links', () => {
+  it('is defined', () => {
+    const el = document.createElement('outline-admin-links');
+    assert.instanceOf(el, OutlineAdminLinks);
+  });
+
+  it('renders with default values', async () => {
+    const el = await fixture(html`<outline-admin-links></outline-admin-links>`);
+    assert.shadowDom.equal(
+      el,
+      `<div class="links">
+        <slot></slot>
+      </div>`
+    );
+  });
+
+  it('renders slotted content in shadowDOM', async () => {
+    const el = await fixture(
+      html`<outline-admin-links>
+        <ul>
+          <li><a href="#"> Ping </a></li>
+        </ul>
+      </outline-admin-links>`
+    );
+
+    await elementUpdated(el);
+    assert.shadowDom.equal(
+      el,
+      `
+      <div class="links">
+        <ul>
+          <li>
+            <a href="#">
+              Ping
+            </a>
+          </li>
+        </ul>
+        <slot>
+        </slot>
+      </div>`
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds tests to `outline-admin-links`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

