### PR TITLE
Issue 289: Fixes `outline-accordion` and `outline-accordion-panel` click behavior

### DIFF
--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.stories.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.stories.ts
@@ -1,7 +1,7 @@
 import { html, TemplateResult } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import './outline-accordion-panel';
-
+import '../outline-styled-text/outline-styled-text';
 export default {
   title: 'Content/Accordion/Accordion Panel',
   component: 'outline-accordion-panel',
@@ -10,7 +10,7 @@ export default {
       source: {
         code: `<outline-accordion-panel clean=clean active=active>
                 <h3 slot="heading">Panel the First</h3>
-                <div class="wysiwyg">
+                <outline-styled-text>
                   <h3>Etiam ut purus mattis mauris</h3>
                   <p>Suspendisse eu ligula.Proin pretium,
                    leo ac pellentesque mollis, felis nunc ultrices eros,
@@ -24,7 +24,7 @@ export default {
                    sodales nec, volutpat a, suscipit non, turpis.
                    Fusce vulputate eleifend sapien.
                    </p>
-                </div >
+                </outline-styled-text>
               </outline-accordion-panel>`,
       },
     },
@@ -58,9 +58,9 @@ export default {
   args: {
     clean: false,
     active: false,
-    headingSlotContent: '<h5 slot="heading">Panel the First</h5>',
+    headingSlotContent: '<span slot="heading">Panel the First</span>',
     defaultSlotContent:
-      '<div class="wysiwyg"><h6>Etiam ut purus mattis mauris</h6><p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p></div>',
+      '<outline-styled-text><p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p></outline-styled-text>',
   },
 };
 

--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
@@ -3,6 +3,7 @@ import { OutlineElement } from '../outline-element/outline-element';
 import { customElement, property } from 'lit/decorators.js';
 import componentStyles from './outline-accordion-panel.css.lit';
 import { MobileController } from '../../controllers/mobile-controller';
+import { OutlineAccordion } from '../outline-accordion/outline-accordion';
 import '../outline-icon/outline-icon';
 
 /**
@@ -28,7 +29,7 @@ export class OutlineAccordionPanel extends OutlineElement {
    * Wether the panel is active/open.
    * Controlled by parent accordion component.
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true, attribute: true })
   active = false;
 
   /**
@@ -54,6 +55,7 @@ export class OutlineAccordionPanel extends OutlineElement {
           id="${this.id}-button"
           aria-expanded=${this.active}
           aria-controls="${this.id}-info"
+          @click=${this.setActive}
         >
           <span class="accordion-label ${isMobile}">
             <slot name="heading"> </slot>
@@ -82,6 +84,34 @@ export class OutlineAccordionPanel extends OutlineElement {
         <slot></slot>
       </div>
     </div>`;
+  }
+
+  setActive() {
+    const parentWrapper = this.parentElement as OutlineAccordion;
+    const singlePanel = parentWrapper.singlePanel;
+
+    if (singlePanel) {
+      const activePanels = [...parentWrapper.panels].filter(
+        panel => panel.active == true
+      );
+
+      if (activePanels.length < 1) {
+        this.active = true;
+      }
+
+      if (activePanels.length > 0) {
+        activePanels.map(panel => {
+          if (panel.id === this.id) {
+            this.active = false;
+          } else {
+            panel.active = false;
+            this.active = true;
+          }
+        });
+      }
+    } else {
+      this.active = !this.active;
+    }
   }
 }
 

--- a/src/components/base/outline-accordion/outline-accordion.stories.ts
+++ b/src/components/base/outline-accordion/outline-accordion.stories.ts
@@ -2,6 +2,7 @@ import { html, TemplateResult } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import './outline-accordion';
 import '../outline-accordion-panel/outline-accordion-panel';
+import '../outline-styled-text/outline-styled-text';
 
 export default {
   title: 'Content/Accordion/Accordion',
@@ -11,47 +12,35 @@ export default {
       source: {
         code: `
   <outline-accordion label=label clean=clean single-panel=singlePanel>
-  <outline-accordion-panel slot="panels">
-  <span slot="heading">Heading 1</span>
-  <div class="wysiwyg">
-    <h6>Etiam ut purus mattis mauris</h6>
-    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-    </p>
-  </div>
-</outline-accordion-panel>
-<outline-accordion-panel slot="panels">
-  <span slot="heading">Heading 2</span>
-  <div class="wysiwyg">
-    <h6>Etiam ut purus mattis mauris</h6>
-    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-    </p>
-  </div>
-</outline-accordion-panel>
-<outline-accordion-panel slot="panels">
-  <span slot="heading">Heading 3</span>
-  <div class="wysiwyg">
-    <h6>Etiam ut purus mattis mauris</h6>
-    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-    </p>
-  </div>
-</outline-accordion-panel>
-<outline-accordion-panel slot="panels">
-  <span slot="heading">Heading 4</span>
-  <div class="wysiwyg">
-    <h6>Etiam ut purus mattis mauris</h6>
-    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-    </p>
-  </div>
-</outline-accordion-panel>
-<outline-accordion-panel slot="panels">
-  <a slot="heading" href="www.google.com">Heading 5 is a slotted link </a>
-  <div class="wysiwyg">
-    <h6>Etiam ut purus mattis mauris</h6>
-    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-    </p>
-  </div>
-</outline-accordion-panel>
-</outline-accordion>`,
+    <outline-accordion-panel slot="panels">
+      <span slot="heading">Accordion Panel 1</span>
+      <outline-styled-text>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </outline-styled-text>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <span slot="heading">Accordion Panel 2</span>
+      <outline-styled-text>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </outline-styled-text>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <span slot="heading"> Accordion Panel 3</span>
+      <outline-styled-text>
+        <p>Suspendisse eu ligula. Proin pretium, <a style="color: var(--demo-dark-blue)" href="www.google.com"> Click Here to go to Google.com</a> leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </outline-styled-text>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <a slot="heading" href="www.google.com">Accordion Panel 4</a>
+      <outline-styled-text>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </outline-styled-text>
+    </outline-accordion-panel>
+  </outline-accordion>`,
       },
     },
   },
@@ -97,44 +86,32 @@ export default {
     label: 'Frequently Asked Questions',
     PanelsSlotContent: `
     <outline-accordion-panel slot="panels">
-      <span slot="heading">Heading 1</span>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
+      <span slot="heading">Accordion Panel 1</span>
+      <outline-styled-text>
         <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
         </p>
-      </div>
+      </outline-styled-text>
     </outline-accordion-panel>
     <outline-accordion-panel slot="panels">
-      <span slot="heading">Heading 2</span>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
+      <span slot="heading">Accordion Panel 2</span>
+      <outline-styled-text>
         <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
         </p>
-      </div>
+      </outline-styled-text>
     </outline-accordion-panel>
     <outline-accordion-panel slot="panels">
-      <span slot="heading">Heading 3</span>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+      <span slot="heading"> Accordion Panel 3</span>
+      <outline-styled-text>
+        <p>Suspendisse eu ligula. Proin pretium, <a style="color: var(--demo-dark-blue)" href="www.google.com"> Click Here to go to Google.com</a> leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
         </p>
-      </div>
+      </outline-styled-text>
     </outline-accordion-panel>
     <outline-accordion-panel slot="panels">
-      <span slot="heading">Heading 4</span>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
+      <a slot="heading" href="www.google.com">Accordion Panel 4 With Link Heading</a>
+      <outline-styled-text>
         <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
         </p>
-      </div>
-    </outline-accordion-panel>
-    <outline-accordion-panel slot="panels">
-      <a slot="heading" href="www.google.com">Heading 5 is a slotted link </a>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
+      </outline-styled-text>
     </outline-accordion-panel>`,
     clean: false,
     singlePanel: true,

--- a/src/components/base/outline-accordion/outline-accordion.stories.ts
+++ b/src/components/base/outline-accordion/outline-accordion.stories.ts
@@ -11,42 +11,46 @@ export default {
       source: {
         code: `
   <outline-accordion label=label clean=clean single-panel=singlePanel>
-    <outline-accordion-panel slot="panels">
-      <h5 slot="heading">Heading 1</h5>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
-    </outline-accordion-panel>
-      <h5 slot="heading">Heading 2</h5>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
-    </outline-accordion-panel>
-      <h5 slot="heading">Heading 3</h5>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
-    </outline-accordion-panel>
-      <h5 slot="heading">Heading 4</h5>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
-    </outline-accordion-panel>
-      <h5 slot="heading">Heading 5</h5>
-      <div class="wysiwyg">
-        <h6>Etiam ut purus mattis mauris</h6>
-        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
-        </p>
-      </div>
-    </outline-accordion-panel>
+  <outline-accordion-panel slot="panels">
+  <span slot="heading">Heading 1</span>
+  <div class="wysiwyg">
+    <h6>Etiam ut purus mattis mauris</h6>
+    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+    </p>
+  </div>
+</outline-accordion-panel>
+<outline-accordion-panel slot="panels">
+  <span slot="heading">Heading 2</span>
+  <div class="wysiwyg">
+    <h6>Etiam ut purus mattis mauris</h6>
+    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+    </p>
+  </div>
+</outline-accordion-panel>
+<outline-accordion-panel slot="panels">
+  <span slot="heading">Heading 3</span>
+  <div class="wysiwyg">
+    <h6>Etiam ut purus mattis mauris</h6>
+    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+    </p>
+  </div>
+</outline-accordion-panel>
+<outline-accordion-panel slot="panels">
+  <span slot="heading">Heading 4</span>
+  <div class="wysiwyg">
+    <h6>Etiam ut purus mattis mauris</h6>
+    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+    </p>
+  </div>
+</outline-accordion-panel>
+<outline-accordion-panel slot="panels">
+  <a slot="heading" href="www.google.com">Heading 5 is a slotted link </a>
+  <div class="wysiwyg">
+    <h6>Etiam ut purus mattis mauris</h6>
+    <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+    </p>
+  </div>
+</outline-accordion-panel>
 </outline-accordion>`,
       },
     },
@@ -93,36 +97,45 @@ export default {
     label: 'Frequently Asked Questions',
     PanelsSlotContent: `
     <outline-accordion-panel slot="panels">
-    <h5 slot="heading">Heading 1</h5>
-    <div class='wysiwyg'>
-      <h6>Etiam ut purus mattis mauris</h6>
-      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
-    </div>
+      <span slot="heading">Heading 1</span>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
     </outline-accordion-panel>
-
-<outline-accordion-panel slot="panels">
-    <h5 slot="heading">Heading 2</h5>
-    <div class="wysiwyg">
-      <h6>Etiam ut purus mattis mauris</h6>
-      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
-  </div>
-</outline-accordion-panel>
-
-<outline-accordion-panel slot="panels">
-    <h5 slot="heading">Heading 3</h5>
-    <div class="wysiwyg">
-      <h6>Etiam ut purus mattis mauris</h6>
-      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
-  </div>
-</outline-accordion-panel>
-
-<outline-accordion-panel slot="panels">
-    <h5 slot="heading">Heading 4</h5>
-    <div class="wysiwyg">
-      <h6>Etiam ut purus mattis mauris</h6>
-      <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.</p>
-  </div>
-</outline-accordion-panel>`,
+    <outline-accordion-panel slot="panels">
+      <span slot="heading">Heading 2</span>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <span slot="heading">Heading 3</span>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <span slot="heading">Heading 4</span>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>
+    <outline-accordion-panel slot="panels">
+      <a slot="heading" href="www.google.com">Heading 5 is a slotted link </a>
+      <div class="wysiwyg">
+        <h6>Etiam ut purus mattis mauris</h6>
+        <p>Suspendisse eu ligula. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Nam at tortor in tellus interdum sagittis. Morbi ac felis. Etiam ultricies nisi vel augue. Praesent venenatis metus at tortor pulvinar varius. Sed cursus turpis vitae tortor. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Fusce vulputate eleifend sapien.
+        </p>
+      </div>
+    </outline-accordion-panel>`,
     clean: false,
     singlePanel: true,
     allOpen: false,

--- a/src/components/base/outline-accordion/outline-accordion.ts
+++ b/src/components/base/outline-accordion/outline-accordion.ts
@@ -1,14 +1,9 @@
 import { html, TemplateResult, CSSResultGroup } from 'lit';
-import {
-  customElement,
-  property,
-  state,
-  queryAssignedNodes,
-} from 'lit/decorators.js';
+import { customElement, property, queryAssignedNodes } from 'lit/decorators.js';
 import { OutlineElement } from '../../base/outline-element/outline-element';
 import componentStyles from './outline-accordion.css.lit';
 import { MobileController } from '../../controllers/mobile-controller';
-
+import { OutlineAccordionPanel } from '../outline-accordion-panel/outline-accordion-panel';
 /**
  * Accordion Component
  * @element outline-accordion
@@ -45,15 +40,10 @@ export class OutlineAccordion extends OutlineElement {
   allOpen = false;
 
   /**
-   * Array of active/open panels.
-   */
-  @state() active: string[] = [];
-
-  /**
    * ref to <outline-accordion-panels> in panels slot.
    */
   @queryAssignedNodes('panels', true)
-  panels: HTMLSlotElement[];
+  panels: OutlineAccordionPanel[];
 
   render(): TemplateResult {
     return html`
@@ -62,11 +52,7 @@ export class OutlineAccordion extends OutlineElement {
             ${this.label}
           </h4>`
         : null}
-      <div
-        class="accordion"
-        @click=${this.setActive}
-        @keydown=${this.handleKeyboardNav}
-      >
+      <div class="accordion" @keydown=${this.handleKeyboardNav}>
         <slot name="panels"></slot>
       </div>
     `;
@@ -76,26 +62,6 @@ export class OutlineAccordion extends OutlineElement {
    * Takes the element id of content <div>
    * to maintain state list of active/open panels.
    */
-  setActive(e: PointerEvent) {
-    const element = e?.target as HTMLElement;
-    const contentId = element.id;
-
-    // if single-panel = true
-
-    if (this.singlePanel) {
-      if (this.active.includes(contentId)) {
-        return (this.active = []);
-      }
-      return (this.active = [contentId]);
-    }
-
-    // if single-panel = false
-
-    if (this.active.includes(contentId)) {
-      return (this.active = this.active.filter(item => item !== contentId));
-    }
-    return (this.active = [contentId, ...this.active]);
-  }
 
   /**
    * @returns string | null
@@ -143,7 +109,6 @@ export class OutlineAccordion extends OutlineElement {
   firstUpdated() {
     if (this.allOpen) {
       this.panels.map(panel => {
-        this.active.push(panel.id);
         panel.setAttribute('active', 'active');
       });
     }
@@ -153,18 +118,6 @@ export class OutlineAccordion extends OutlineElement {
       this.panels.map(panel => panel.setAttribute('clean', 'clean'));
     } else {
       this.panels.map(panel => panel.removeAttribute('clean'));
-    }
-    if (this.allOpen) {
-      this.panels.map(panel => {
-        this.active.push(panel.id);
-        panel.setAttribute('active', 'active');
-      });
-    } else {
-      this.panels.map(panel =>
-        this.active.includes(panel.id)
-          ? panel.setAttribute('active', 'active')
-          : panel.removeAttribute('active')
-      );
     }
   }
 }


### PR DESCRIPTION
## Description
Refactors `outline-accordion` removing the tracking and management of child `outline-accordion-panel` components, and all associated logic.

Updates 'outline-accordion-panel` to manage its own active state and reference its parent components singlePanel attribute, thus maintaining expected "one-at-a-time" behavior. 

Prevents the `outline-accordion-panel` from closing when the user clicks on the open panel, which prevented the inclusion of links/interactive elements in the panel window.

Updates the `outline-accordion` storybook to demonstrate this behavior and the ability to slot `<a>` in the panel heading slot which has been requested. 

Fixes #289 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Self-tested
passed lint and build without errors or warnings.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/290"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

