### PR TITLE
Gitpod fix: use node-lts as docker image (node v16)

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-node
+FROM gitpod/workspace-node-lts
 
 # Install custom tools, runtime, etc.
 RUN npx playwright install-deps

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@ image:
 tasks:
   - init: |
       yarn
+      nvm install $(cat .nvmrc)
+      nvm use
     command: |
       yarn start
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,8 +4,6 @@ image:
 tasks:
   - init: |
       yarn
-      nvm install $(cat .nvmrc)
-      nvm use
     command: |
       yarn start
 


### PR DESCRIPTION
## Description

Instead of using `nvm` in Gitpod, we should use node-lts as a docker image, which is node v16.

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

