### PR TITLE
A11y fix: use aria-hidden for styling

### DIFF
--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.css
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.css
@@ -72,6 +72,6 @@
   @apply border-0;
 }
 
-[aria-hidden="true"] {
+[aria-hidden='true'] {
   display: none !important;
 }

--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.css
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.css
@@ -71,3 +71,7 @@
 .accordion-panel.clean {
   @apply border-0;
 }
+
+[aria-hidden="true"] {
+  display: none !important;
+}

--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
@@ -78,7 +78,6 @@ export class OutlineAccordionPanel extends OutlineElement {
         role="region"
         aria-labelledby="${this.id}-button"
         id="${this.id}-info"
-        .hidden=${!this.active}
         aria-hidden="${!this.active}"
       >
         <slot></slot>

--- a/src/components/base/outline-accordion/outline-accordion.css
+++ b/src/components/base/outline-accordion/outline-accordion.css
@@ -14,3 +14,7 @@
 .accordion-title.mobile:after {
   @apply mt-2 mb-4 w-4 border;
 }
+
+[aria-hidden="true"] {
+  display: none !important;
+}

--- a/src/components/base/outline-accordion/outline-accordion.css
+++ b/src/components/base/outline-accordion/outline-accordion.css
@@ -15,6 +15,6 @@
   @apply mt-2 mb-4 w-4 border;
 }
 
-[aria-hidden="true"] {
+[aria-hidden='true'] {
   display: none !important;
 }


### PR DESCRIPTION
## Description

Accessibility best practice says to change the style of an element base on aria when possible.
Accordion was using an attribute `hidden`, this PR remove that attribute and update CSS to depend on `aria-hidden` instead.
(The end result is the same)

## How Has This Been Tested?
I tested the Accordion component in storybook, and confirmed accordion panels are shown/hidden.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/297"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

