### PR TITLE
Demonstration: sandbox component that shows how queries for slots work

### DIFF
--- a/src/components/sandbox/slot-query/slot-query.stories.ts
+++ b/src/components/sandbox/slot-query/slot-query.stories.ts
@@ -57,7 +57,7 @@ const Template = (args = configuration.args): TemplateResult => {
         <slot-query>
           <div slot="nested">
             ${unsafeHTML(args.nestedSlotContent ?? '')}
-          <div/>
+          </div>
         </slot-query>
       </div>
     </slot-query>

--- a/src/components/sandbox/slot-query/slot-query.stories.ts
+++ b/src/components/sandbox/slot-query/slot-query.stories.ts
@@ -1,0 +1,67 @@
+import { html, TemplateResult } from 'lit';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import './slot-query';
+
+const configuration = {
+  title: 'Sandbox/SlotQuery',
+  component: 'slot-query',
+  argTypes: {
+    unnestedSlotContent: {
+      description: 'Content that will not be in a nested slot.',
+      name: 'slot="unnested"',
+      table: {
+        category: 'Slots',
+      },
+      control: { type: 'text' },
+    },
+    nestedSlotContent: {
+      name: 'slot="nested"',
+      description: 'Content that will be in a nested slot.',
+      table: {
+        category: 'Slots',
+      },
+      control: { type: 'text' },
+    },
+  },
+  args : {
+    unnestedSlotContent: `unnested slot content`,
+    nestedSlotContent: `nested slot content`,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This demonstrates how element queries work with nested components and slots.
+
+View the developer console to see messages.
+        `,
+      },
+    },
+  },
+};
+
+export default configuration;
+
+const Template = (args = configuration.args): TemplateResult => {
+  args = {
+    ...configuration.args,
+    ...args,
+  };
+
+  return html`
+    <slot-query>
+      <div slot="unnested">
+        ${unsafeHTML(args.unnestedSlotContent ?? '')}
+      </div>
+      <div slot="nested">
+        <slot-query>
+          <div slot="nested">
+            ${unsafeHTML(args.nestedSlotContent ?? '')}
+          <div/>
+        </slot-query>
+      </div>
+    </slot-query>
+  `;
+};
+
+export const SlotQuery = Template.bind({});

--- a/src/components/sandbox/slot-query/slot-query.ts
+++ b/src/components/sandbox/slot-query/slot-query.ts
@@ -1,0 +1,40 @@
+import { html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { OutlineElement } from '../../base/outline-element/outline-element';
+
+const elementName = 'slot-query';
+
+/**
+ * Slot query component.
+ *
+ * @element slot-query
+ * @slot unnested
+ * @slot nested
+ */
+@customElement(elementName)
+export class SlotQuery extends OutlineElement {
+  render(): TemplateResult {
+    this._logQuery(`[slot="unnested"]`);
+    this._logQuery(`[slot="nested"]`);
+    this._logQuery(`:scope > [slot="unnested"]`);
+    this._logQuery(`:scope > [slot="nested"]`);
+
+    return html`
+      <div id="slot-query">
+        <slot name="unnested"></slot>
+        <slot name="nested"></slot>
+      </div>
+    `;
+  }
+
+  _logQuery(query: string): void {
+    // eslint-disable-next-line
+    console.log(this, query, this.querySelectorAll(query));
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slot-query': SlotQuery;
+  }
+}


### PR DESCRIPTION
## Description

**Not intended to be merged. For demonstration only.**

Shows how `querySelectorAll` will find nested slots if we use only `[slot="my-slot"]`, while `:scope > [slot="my-slot"]` will only find the slots for the webcomponent itself.

Namespacing slots like `my-component--my-slot` reduces, but does not eliminate this issue. Most components won't have themselves within them, but some might, such as layout components.

This really is mostly an issue for things like default slots or other common names like `image` or `title`.

If for example you have a listing with a hero image and child cards, you may use `image` on the listing component as well as in the child cards.

## Testing steps

- Visit /?path=/story/sandbox-slotquery--slot-query
- View the console logs

## Examples

![nested_slots](https://user-images.githubusercontent.com/397902/162980146-b3d307f1-816c-48ea-808e-cef7b8c21230.jpg)

```html
<slot-query>
  <div slot="unnested">
    unnested slot content
  </div>
  <div slot="nested">
    <slot-query>
      <div slot="nested">
        nested slot content
      </div>
    </slot-query>
  </div>
</slot-query>
```

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/304"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

