### PR TITLE
Let the `MobileController` class be configured per instance

### DIFF
--- a/outline.config.js
+++ b/outline.config.js
@@ -15,6 +15,15 @@ module.exports = {
     dir: ['src/assets'],
     sync: ['dist', 'src/.storybook/static/dist'],
   },
+  screens: {
+    xs: '480px',
+    sm: '640px',
+    md: '768px',
+    lg: '1024px',
+    xl: '1280px',
+    xxl: '1440px',
+    xxxl: '1440px',
+  },
   css: {
     global: [
       {

--- a/src/components/controllers/mobile-controller.ts
+++ b/src/components/controllers/mobile-controller.ts
@@ -1,11 +1,13 @@
+import outline from '../../resolved-outline-config';
 import { ReactiveControllerHost, ReactiveController } from 'lit';
-import tailwindThemeConfig from '../../resolved-tailwind-config';
 //TODO: add functionality to receive array of screen sizes to map to object in controller state
 export class MobileController implements ReactiveController {
   isMobile = false;
   host: ReactiveControllerHost;
+  mobileBreakpoint: string;
 
-  constructor(host: ReactiveControllerHost) {
+  constructor(host: ReactiveControllerHost, mobileBreakpoint = 'md') {
+    this.mobileBreakpoint = mobileBreakpoint;
     (this.host = host).addController(this);
     this.handleResize();
   }
@@ -19,10 +21,12 @@ export class MobileController implements ReactiveController {
   }
 
   handleResize = () => {
-    const tailwindMdScreen = this.formatScreenSize(
-      tailwindThemeConfig.screens.md
+    const mobileScreen = this.formatScreenSize(
+      // @TODO: FIX THIS Typing.
+      // @ts-expect-error shrug
+      outline.screens[this.mobileBreakpoint]
     );
-    if (window.innerWidth <= tailwindMdScreen) {
+    if (window.innerWidth <= mobileScreen) {
       this.isMobile = true;
     } else {
       this.isMobile = false;


### PR DESCRIPTION
## Description

Currently the `MobileController` assumes `md` is the point we want to switch to mobile. This obviously doesn't fit every use case. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Testing

## Implementations 

Previously, it would look like this when we used the `MobileController`: 

```typescript
private mobileController = new MobileController(this);
```
Now, while `md` is still the default (no regressions), we can use it like this:

```typescript
private mobileController = new MobileController(this, 'lg');
private mobileController = new MobileController(this, 'sm');
etc...
```

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/305"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

