### PR TITLE
chore: add best practices for extending components

### DIFF
--- a/src/.storybook/stories/guides/development/component-development/11-extending.stories.mdx
+++ b/src/.storybook/stories/guides/development/component-development/11-extending.stories.mdx
@@ -25,6 +25,11 @@ import '../../../../../components/base/outline-code-block/outline-code-block';
 > This section will provide an in-depth overview of extending components with Lit and Outline. 
 > The abiilty to extend components is one of, if not the core reason we utilize Lit as the standard for Outine component development.
 
+## Best Practices
+
+Whenever a `.ts` file requires an update, it's recommended to extend that element to a specific element of your design system.
+ie. when customizing the button component functionality beyond CSS styling, extend `outline-button` to `acme-button`.
+
 ## Extending Components in Outline
 
 Lit gives us the ability to extend the base `LitElement` component class as well as our own custom component classes. 


### PR DESCRIPTION
## Description

Added the following text to "Extending Components" storybook documentation -
```
## Best Practices
Whenever a `.ts` file requires an update, it's recommended to extend that element to a specific element of your design system.
ie. when customizing the button component functionality beyond CSS styling, extend `outline-button` to `acme-button`.
```

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

