### PR TITLE
Fix for `LinkedBlockController` double click handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Pull requests are greatly appreciated! To ensure a smooth review process, please
 3. All PRs that change behavior or fix bugs should have new or updated tests.
 4. Try to create a set of descriptive commits that each do one focused change. Avoid commits like "oops", and prefer commits like "Added method foo to Bar".
 5. When addressing review comments, try to add new commits, rather than modifying previous commits. This makes it easier for reviewers to see what changed since the last review. 
-6. Please run `yarn lint` and `yarn fmt` before submitting PRs. PRs that don't lint and aren't formatted will fail continuous integration tests.
+6. Please run `yarn lint` and `yarn format` before submitting PRs. PRs that don't lint and aren't formatted will fail continuous integration tests.
 
 ---
 
@@ -90,12 +90,12 @@ BREAKING CHANGE - Requires a rewrite of all your code.
 
 ## Code Cleanup
 
-Code is not automatically formatted upon commit. As a matter of best practices, you should run `yarn fmt` and `yarn lint` prior to committing code to prevent pipelines from failing in the `Test and Build` task.
+Code is not automatically formatted upon commit. As a matter of best practices, you should run `yarn format` and `yarn lint` prior to committing code to prevent pipelines from failing in the `Test and Build` task.
 
 ### Run all Prettier and SVG formatting
 
 ```bash
-yarn fmt
+yarn format
 ```
 
 ---
@@ -103,7 +103,7 @@ yarn fmt
 ### Run Prettier formatting
 
 ```bash
-yarn fmt.code
+yarn format:code
 ```
 
 ---
@@ -111,7 +111,7 @@ yarn fmt.code
 ### Run svgo formatting
 
 ```bash
-yarn fmt.svg
+yarn format:svg
 ```
 
 ---

--- a/src/components/controllers/linked-block-controller.ts
+++ b/src/components/controllers/linked-block-controller.ts
@@ -57,13 +57,32 @@ export class LinkedBlockController implements ReactiveController {
     });
 
     this.host.addEventListener('mouseup', (event: Event) => {
-      if (event.target !== this._getLink() && this._isClickNotDrag()) {
+      // First element in the event's composedPath is the element returned by this._getLink(),
+      // but the event.target is the shadow host element, even when the click event is triggered
+      // programmatically on this._getLink().
+      if (
+        event.composedPath()[0] !== this._getLink() &&
+        this._isClickNotDrag()
+      ) {
+        event.stopPropagation();
+
+        this._getLink()?.dispatchEvent(new Event('mousedown'));
+        this._getLink()?.dispatchEvent(new Event('mouseup'));
+      }
+    });
+
+    this.host.addEventListener('click', (event: Event) => {
+      // First element in the event's composedPath is the element returned by this._getLink(),
+      // but the event.target is the shadow host element, even when the click event is triggered
+      // programmatically on this._getLink().
+      if (
+        event.composedPath()[0] !== this._getLink() &&
+        this._isClickNotDrag()
+      ) {
         event.stopPropagation();
 
         // Could only get `click` to trigger `a` elements, but it doesn't trigger the `mousedown` and `mouseup` events for nested elements.
         this._getLink()?.click();
-        this._getLink()?.dispatchEvent(new Event('mousedown'));
-        this._getLink()?.dispatchEvent(new Event('mouseup'));
       }
     });
   }


### PR DESCRIPTION
## Description

Fixes an issue affecting components that use the `LinkedBlockController` controller. Issue was that clicking on the component results in two click events: the one that the user actually initiated, and the one programmatically triggered with this._getLink()?.click();. The double click events can interfere with web analytics tracking.

Fixes #309 

## Type of change

Please delete options that are not relevant.

- [ √] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [ √] My code follows the style guidelines of this project
- [ √] I have performed a self-review of my own code
- [ √] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ √] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/310"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

