### PR TITLE
fix: install rsync in Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,7 @@
 FROM gitpod/workspace-node-lts
 
+RUN sudo apt-get -qq update
+RUN sudo apt-get -qq install -y rsync
+
 # Install custom tools, runtime, etc.
 RUN npx playwright install-deps


### PR DESCRIPTION
## Description
Pre-install `rsync` application on Gitpod.

Fixes # (issue)
The `rsync` dependency in `package.json` is only a wrapper for the real `rsync` application, which is assumed to be installed on your machine.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Opening this PR in Gitpod
1. Run `rm -rf dist`
1. Run `yarn prep`
1. Confirm `dist/` directory includes `assets` in it

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/315"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

