### PR TITLE
`outline-image`: Updates to base image component

### DIFF
--- a/outline.config.js
+++ b/outline.config.js
@@ -53,8 +53,8 @@ module.exports = {
       // @status stable
       full: true,
       // @see src/data.ts
-      // @status optional
-      data: false,
+      // @status stable
+      data: true,
     },
   },
   // @todo: Importing this into swatch-sets causes issues.

--- a/outline.config.js
+++ b/outline.config.js
@@ -54,7 +54,7 @@ module.exports = {
       full: true,
       // @see src/data.ts
       // @status stable
-      data: true,
+      data: false,
     },
   },
   // @todo: Importing this into swatch-sets causes issues.

--- a/src/components/base/outline-image/outline-image.css
+++ b/src/components/base/outline-image/outline-image.css
@@ -1,33 +1,52 @@
 :host {
-  @apply block;
+  display: block;
 
-  &([parallax]) figure {
-    @apply h-half-screen-h;
-    clip-path: inset(0 0 0 0);
-  }
-
-  &([parallax='false']) figure {
-    @apply h-auto;
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-@screen lg {
-  :host {
-    &([parallax='false']) figure {
-      @apply h-auto;
-    }
+  figure {
+    margin: 0;
+    display: block;
+    height: auto;
   }
 }
 
 figure {
-  @apply m-0 block;
+  width: 100%;
+  height: 100%;
+  display: flex;
 }
 
-::slotted([slot='caption']) {
-  @apply mt-2 font-body text-sm;
+picture {
+  aspect-ratio: default;
+  overflow: hidden;
+  display: flex;
 }
 
-::slotted(img) {
-  @apply w-full;
+img {
+  object-fit: cover;
+  height: auto;
+  min-width: 100%;
+}
+
+:host([image-ratio='1/1']) picture {
+  aspect-ratio: 1 / 1;
+}
+:host([image-ratio='3/2']) picture {
+  aspect-ratio: 3 / 2;
+}
+:host([image-ratio='3/4']) picture {
+  aspect-ratio: 3 / 4;
+}
+:host([image-ratio='4/3']) picture {
+  aspect-ratio: 4 / 3;
+}
+:host([image-ratio='5/4']) picture {
+  aspect-ratio: 5 / 4;
+}
+:host([image-ratio='16/9']) picture {
+  aspect-ratio: 16 / 9;
+}
+:host([image-ratio='9/16']) picture {
+  aspect-ratio: 9 / 16;
+}
+:host([image-ratio='21/9']) picture {
+  aspect-ratio: 21 / 9;
 }

--- a/src/components/base/outline-image/outline-image.stories.ts
+++ b/src/components/base/outline-image/outline-image.stories.ts
@@ -1,6 +1,13 @@
 import { html, TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import sampleImage from '../../../.storybook/static/media/color/Creative_Process_color.jpg';
+import code1 from '../../../.storybook/static/media/tech/1440/code-1.jpg';
+import code2 from '../../../.storybook/static/media/tech/1440/code-2.jpg';
+import code3 from '../../../.storybook/static/media/tech/1440/code-3.jpg';
+import code4 from '../../../.storybook/static/media/tech/1440/code-4.jpg';
+import code5 from '../../../.storybook/static/media/tech/1440/code-5.jpg';
+import code6 from '../../../.storybook/static/media/tech/1440/code-6.jpg';
+import code7 from '../../../.storybook/static/media/tech/1440/code-7.jpg';
+import { imageDisplayMethodData, imageRatioPropertyData, NarrowStoryDecorator } from '../../../data';
 import { argTypeHidden } from '../outline-element/utils/utils';
 import './outline-image';
 // import '../outline-heading/outline-heading'
@@ -15,53 +22,184 @@ export default {
         component: `
 This component renders an image with an optional caption as a \`figure\` element and a \`figcaption\` element.
 
-## Difference between \`figure\` and \`figcaption\` element
+## Description & Usage
 
-_@todo describe why this would be used instead._
+- Providing an \`image-href\` attribute will create a simple image tag based on the provided URL. The \`image-label\` attribute is optional and will be used as the alt text for the image.
+- Providing a standard \`picture\` element, wrapping an \`img\` tag to the default slot will allow the consumer to provide the image markup, while allowing for standardized styling with property created images. 
 
-        `,
-      },
-      source: {
-        code: `
-<outline-image>
-  {{ defaultSlot }}
-  <outline-container slot="caption">{{ caption }}</outline-container>
-</outline-image>
+## Sample Demonstrations
+The \`Image (Configurable)\` story is completely testable by changing the render type, and aspect ratio. 
+Additional stories will will indicate the ratio being used, and and the method of rendering the image.
         `,
       },
     },
   },
   argTypes: {
+    imageRatio: imageRatioPropertyData('image-ratio'),
+    imageMode: imageDisplayMethodData('Render Method'),
     imageUrl: argTypeHidden,
-    parallaxContainer: argTypeHidden,
-    el: argTypeHidden,
-    caption: {
-      control: {
-        type: 'text',
-      },
-    },
+    imageLabel: argTypeHidden,
+    caption: argTypeHidden,
   },
   args: {
-    imageUrl: sampleImage,
-    caption: '',
+    imageLabel: 'Picture of a thing',
+    imageMode: 'slot',
   },
 };
 
-const Template = ({ imageUrl, caption, parallax }): TemplateResult => html`
-  <outline-image parallax="${ifDefined(parallax)}">
-    <img src="${imageUrl}" alt="Random Image" />
-    <outline-container slot="caption">${caption}</outline-container>
-  </outline-image>
-`;
+const Template = ({ imageUrl, imageRatio, imageLabel, imageMode, caption }): TemplateResult => html`
+${imageMode == 'prop' ? html`
+<outline-image image-href="${ifDefined(imageUrl)}" image-label="${ifDefined(imageLabel)}" image-ratio="${ifDefined(imageRatio)}">
+  ${caption ? html`<div slot="caption">${caption}</div>` : null}
+</outline-image>
+` : html`
+<outline-image image-ratio="${ifDefined(imageRatio)}">
+  <picture><img src="${imageUrl}" alt="${imageLabel}" /></picture>
+  ${caption ? html`<div slot="caption">${caption}</div>` : null}
+</outline-image>
+`}`;
 
-export const StaticImage = Template.bind({});
-
-export const ImageWithCaption = Template.bind({});
-ImageWithCaption.args = {
-  caption: 'A simple caption text',
+export const ImageDefault = Template.bind({});
+ImageDefault.args = {
+  imageUrl: code6,
+  imageRatio: '21/9',
+  imageMode: 'slot',
 };
-ImageWithCaption.decorators = [
-  //TODO determine appropriate typing for Story
-  (Story): TemplateResult =>
-    html` <div class="w-9/12 mx-auto">${Story()}</div> `,
-];
+
+ImageDefault.storyName = 'Image (Configurable)';
+
+export const ImageOne = Template.bind({});
+ImageOne.args = {
+  imageUrl: code1,
+  imageRatio: '1/1',
+  imageMode: 'prop',
+};
+ImageOne.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`1:1\` aspect ratio and is using the \`prop\` image display method. 
+    `},
+  },
+};
+ImageOne.decorators = NarrowStoryDecorator;
+ImageOne.storyName = 'Image: 1:1';
+
+export const ImageTwo = Template.bind({});
+ImageTwo.args = {
+  imageUrl: code2,
+  imageRatio: '3/2',
+  imageMode: 'slot',
+};
+ImageTwo.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`3:2\` aspect ratio and is using the \`slot\` image display method. 
+    `},
+  },
+};
+ImageTwo.decorators = NarrowStoryDecorator;
+ImageTwo.storyName = 'Image: 3:2';
+
+export const ImageThree = Template.bind({});
+ImageThree.args = {
+  imageUrl: code3,
+  imageRatio: '3/4',
+  imageMode: 'prop',
+};
+ImageThree.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`3:4\` aspect ratio and is using the \`prop\` image display method. 
+    `},
+  },
+};
+ImageThree.decorators = NarrowStoryDecorator;
+ImageThree.storyName = 'Image: 3:4';
+
+export const ImageFour = Template.bind({});
+ImageFour.args = {
+  imageUrl: code4,
+  imageRatio: '4/3',
+  imageMode: 'slot',
+};
+ImageFour.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`4:3\` aspect ratio and is using the \`slot\` image display method. 
+    `},
+  },
+};
+ImageFour.decorators = NarrowStoryDecorator;
+ImageFour.storyName = 'Image: 4:3';
+
+export const ImageFive = Template.bind({});
+ImageFive.args = {
+  imageUrl: code5,
+  imageRatio: '5/4',
+  imageMode: 'prop',
+};
+ImageFive.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`5:4\` aspect ratio and is using the \`prop\` image display method. 
+    `},
+  },
+};
+ImageFive.decorators = NarrowStoryDecorator;
+ImageFive.storyName = 'Image: 5:4';
+
+export const ImageSix = Template.bind({});
+ImageSix.args = {
+  imageUrl: code6,
+  imageRatio: '16/9',
+  imageMode: 'slot',
+};
+ImageSix.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`16:9\` aspect ratio and is using the \`slot\` image display method. 
+    `},
+  },
+};
+ImageSix.decorators = NarrowStoryDecorator;
+ImageSix.storyName = 'Image: 16:9';
+
+export const ImageSeven = Template.bind({});
+ImageSeven.args = {
+  imageUrl: code7,
+  imageRatio: '9/16',
+  imageMode: 'prop',
+};
+ImageSeven.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`9/16\` aspect ratio and is using the \`prop\` image display method. 
+    `},
+  },
+};
+ImageSeven.decorators = NarrowStoryDecorator;
+ImageSeven.storyName = 'Image: 9:16';
+
+export const ImageEight = Template.bind({});
+ImageEight.args = {
+  imageUrl: code3,
+  imageRatio: '21/9',
+  imageMode: 'slot',
+};
+ImageEight.parameters = {
+  docs: {
+    description: {
+      story: `
+The following sample is set to a \`21:9\` aspect ratio and is using the \`slot\` image display method. 
+    `},
+  },
+};
+ImageEight.decorators = NarrowStoryDecorator;
+ImageEight.storyName = 'Image: 21:9';

--- a/src/components/base/outline-image/outline-image.ts
+++ b/src/components/base/outline-image/outline-image.ts
@@ -1,24 +1,66 @@
 import { html, TemplateResult } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { SlotController } from '../../controllers/slot-controller';
 import { OutlineElement } from '../outline-element/outline-element';
 import componentStyles from './outline-image.css.lit';
 
+export const aspectRatios = [
+  'default',
+  '1/1',
+  '3/2',
+  '3/4',
+  '4/3',
+  '5/4',
+  '16/9',
+  '9/16',
+  '21/9',
+] as const;
+export type AspectRatios = typeof aspectRatios[number];
 /**
  * The image component, with support for parallax scrolling.
  * @element outline-image
- *
+ * @extends OutlineElement
+ * @see https://codepen.io/alvarotrigo/pen/OJxOrOg
+ * @see https://keithclark.co.uk/articles/pure-css-parallax-websites/demo3/
  * @slot default - The image to be presented.
  * @slot caption - The caption text for the image.
  */
 @customElement('outline-image')
 export class OutlineImage extends OutlineElement {
+  slots = new SlotController(this, true);
   static styles = [componentStyles];
 
-  @state()
-  hasCaptionSlot: boolean;
+  @state() hasCaptionSlot: boolean;
+
+  /**
+   * Image url
+   */
+  @property({ type: String, attribute: 'image-href' })
+  imageHref: string | boolean = false;
+
+  /**
+   * Image text
+   */
+  @property({ type: String, attribute: 'image-label' })
+  imageLabel: string | boolean = false;
+
+  /**
+   * Image aspect ratio.
+   *
+   * This value can be customized per image usage.
+   * It will work with the property usages of image-href and image-label.
+   *
+   * If using a slotted image, it will work if the structure is an
+   * img tag wrapped in a picture tag.
+   *
+   * @todo: Add image ratio per breakpoint.
+   */
+  @property({ type: String, attribute: 'image-ratio', reflect: true })
+  imageRatio: AspectRatios;
 
   firstUpdated(): void {
-    this.hasCaptionSlot = this.querySelector('[slot="caption"]') !== null;
+    this.hasCaptionSlot = this.slots.test('caption');
   }
 
   captionSlotTemplate(): TemplateResult | null {
@@ -28,10 +70,14 @@ export class OutlineImage extends OutlineElement {
   }
 
   render(): TemplateResult {
-    return html`
-      <figure><slot></slot></figure>
-      ${this.captionSlotTemplate()}
-    `;
+    return html`${this.imageHref
+      ? html` <figure>
+          <picture>
+            <img src=${this.imageHref} alt="${ifDefined(this.imageLabel)}" />
+          </picture>
+        </figure>`
+      : html`<figure><slot></slot></figure>`}
+    ${this.captionSlotTemplate()} `;
   }
 }
 

--- a/src/components/base/outline-image/outline-image.ts
+++ b/src/components/base/outline-image/outline-image.ts
@@ -23,7 +23,7 @@ export type AspectRatios = typeof aspectRatios[number];
  * @extends OutlineElement
  * @see https://codepen.io/alvarotrigo/pen/OJxOrOg
  * @see https://keithclark.co.uk/articles/pure-css-parallax-websites/demo3/
- * @slot default - The image to be presented.
+ * @slot - The image to be presented.
  * @slot caption - The caption text for the image.
  */
 @customElement('outline-image')

--- a/src/components/base/outline-image/test/outline-image.test.ts
+++ b/src/components/base/outline-image/test/outline-image.test.ts
@@ -49,7 +49,7 @@ describe('outline-image', () => {
   it('renders caption slotted content', async () => {
     const el = await fixture(
       html`<outline-image
-        ><img alt="An image" />
+        ><picture><img src="image.jpg" alt="An image" /></picture>
         <p slot="caption">A test caption</p></outline-image
       >`
     );

--- a/src/components/base/outline-image/test/outline-image.test.ts
+++ b/src/components/base/outline-image/test/outline-image.test.ts
@@ -57,7 +57,7 @@ describe('outline-image', () => {
       el,
       `
       <figure><picture><img src="image.jpg" alt='An image' /></picture><slot></slot></figure>
-      <figcaption><p slot='caption'>A test caption</p></figcaption>
+      <figcaption><slot name="caption"><p slot='caption'>A test caption</p></slot></figcaption>
       `
     );
   });

--- a/src/components/base/outline-image/test/outline-image.test.ts
+++ b/src/components/base/outline-image/test/outline-image.test.ts
@@ -19,12 +19,29 @@ describe('outline-image', () => {
 
   it('renders slotted content', async () => {
     const el = await fixture(
-      html`<outline-image><img alt="Im an image" /></outline-image>`
+      html`<outline-image
+        ><picture><img src="image.jpg" alt="An image" /></picture
+      ></outline-image>`
     );
-    assert.lightDom.equal(
+    assert.shadowDom.equal(
       el,
       `
-      <img alt='Im an image' />
+      <figure><picture><img src="image.jpg" alt='An image' /></picture><slot></slot></figure>
+      `
+    );
+  });
+
+  it('renders image with properties', async () => {
+    const el = await fixture(
+      html`<outline-image
+        image-href="image.jpg"
+        image-label="An image"
+      ></outline-image>`
+    );
+    assert.shadowDom.equal(
+      el,
+      `
+      <figure><picture><img src="image.jpg" alt='An image' /></picture></figure>
       `
     );
   });
@@ -32,15 +49,15 @@ describe('outline-image', () => {
   it('renders caption slotted content', async () => {
     const el = await fixture(
       html`<outline-image
-        ><img alt="Im an image" />
-        <p slot="caption">Im a test caption</p></outline-image
+        ><img alt="An image" />
+        <p slot="caption">A test caption</p></outline-image
       >`
     );
-    assert.lightDom.equal(
+    assert.shadowDom.equal(
       el,
       `
-      <img alt='Im an image' />
-      <p slot='caption'>Im a test caption</p>
+      <figure><picture><img src="image.jpg" alt='An image' /></picture><slot></slot></figure>
+      <figcaption><p slot='caption'>A test caption</p></figcaption>
       `
     );
   });

--- a/src/data.ts
+++ b/src/data.ts
@@ -145,6 +145,6 @@ export const imageDisplayMethodData = (
 // },
 
 export const NarrowStoryDecorator = [
-  (Story): TemplateResult =>
+  (Story: () => unknown): TemplateResult =>
     html` <div class="block max-w-[600px]">${Story()}</div> `,
 ];

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,4 +2,149 @@
  * @file src/data.ts
  * This file should contain various sample data and shared functions.
  */
+import { html, TemplateResult } from 'lit';
+import { aspectRatios } from './components/base/outline-image/outline-image';
+
 export const sampleData = {};
+
+export const eyebrowSlotData = {
+  name: 'slot="eyebrow"',
+  description: 'The text for the eyebrow.',
+  table: {
+    category: 'Slots',
+    defaultValue: { summary: 'NULL' },
+  },
+  control: {
+    type: 'text',
+  },
+};
+
+export const titleSlotData = {
+  name: 'slot="title"',
+  description: 'The text for the title.',
+  table: {
+    category: 'Slots',
+    defaultValue: { summary: 'NULL' },
+  },
+  control: {
+    type: 'text',
+  },
+};
+
+export const summarySlotData = {
+  name: 'slot="summary"',
+  description: 'The summary for the card content.',
+  table: {
+    category: 'Slots',
+    defaultValue: { summary: 'NULL' },
+  },
+  control: {
+    type: 'text',
+  },
+};
+
+export const contentSlotData = {
+  name: 'slot="content"',
+  description: 'The text for the card content.',
+  table: {
+    category: 'Slots',
+    defaultValue: { summary: 'NULL' },
+  },
+  control: {
+    type: 'text',
+  },
+};
+
+export const ctaSlotData = {
+  name: 'slot="cta"',
+  description: 'The text for the button CTA.',
+  table: {
+    category: 'Slots',
+    defaultValue: { summary: 'NULL' },
+  },
+  control: {
+    type: 'text',
+  },
+};
+
+export const backgroundPropertyData = (attributeName: string) => {
+  return {
+    name: attributeName,
+    control: {
+      type: 'select',
+    },
+    options: ['gray', 'blue', 'white', 'transparent'],
+    table: {
+      category: 'Properties',
+      defaultValue: { summary: 'transparent' },
+    },
+    description: 'Color to apply to the card background.',
+  };
+};
+
+export const paddingPropertyData = (attributeName: string) => {
+  return {
+    name: attributeName,
+    control: {
+      type: 'select',
+    },
+    options: ['none', 'small', 'medium', 'large'],
+    table: {
+      category: 'Properties',
+      defaultValue: { summary: 'medium' },
+    },
+    description: 'An amount of padding to apply to a wrapper element.',
+  };
+};
+
+export const imageRatioPropertyData = (
+  attributeName: string,
+  category = 'Properties'
+) => {
+  return {
+    name: attributeName,
+    control: {
+      type: 'select',
+    },
+    options: aspectRatios,
+    table: {
+      category: category,
+      defaultValue: { summary: 'default' },
+    },
+    description: 'The aspect ratio to apply to an image element.',
+  };
+};
+
+export const imageDisplayMethodData = (
+  attributeName: string,
+  category = 'Other Controls'
+) => {
+  return {
+    name: attributeName,
+    control: {
+      type: 'radio',
+    },
+    options: ['slot', 'prop'],
+    table: {
+      category: category,
+      defaultValue: { summary: 'slot' },
+    },
+    description: `
+ Which method to demonstrate when rendering the image. 
+ This is not an actual property on the component, but a sample configuration for Storybook testing.
+ - \`slot\`: Use the default slot to render the image.
+ - \`prop\`: Use properties to render the image.`,
+  };
+};
+
+// statusType: {
+//   description:
+//     'The status type of the alert. Such as `information` or `warning`.',
+//   options: alertStatusTypes,
+//   control: { type: 'select' },
+// },
+
+export const NarrowStoryDecorator = [
+  (Story): TemplateResult =>
+    html` <div class="block max-w-[600px]">${Story()}</div> `,
+];


### PR DESCRIPTION
## Description

The changes above allow for a more flexible image component.
Like the `outline-link` component, the image component can now be rendered via either slots or properties. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [X] Visual Testing
- [X] Accessibility Testing

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/318"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

