### PR TITLE
fix: vertically centered icons

### DIFF
--- a/src/components/base/outline-icon/outline-icon.css
+++ b/src/components/base/outline-icon/outline-icon.css
@@ -1,4 +1,5 @@
 :host svg {
   height: inherit;
   width: inherit;
+  display: flex;
 }


### PR DESCRIPTION
## Description

Icons are not vertically centered in Outline, it's especially noticeable in buttons with icons, where we need the text and icon to align.

Before:
![image](https://user-images.githubusercontent.com/22901/169543638-5cb41b02-f52e-4a14-bca5-de546e92a426.png)

After:
![image](https://user-images.githubusercontent.com/22901/169543735-99d432c0-bd84-4f88-a42f-656bfb86ebaf.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Visual Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/325"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

