### PR TITLE
Fix: Tabnabbing vulnerability protection

### DIFF
--- a/dev/link.html
+++ b/dev/link.html
@@ -35,7 +35,12 @@
         <outline-link link-href="https://outline.phase2tech.com">
           Link using properties, with slotted link text
         </outline-link>
-    </p>
+      </p>
+      <p>
+        <outline-link link-href="https://outline.phase2tech.com" link-target="_blank">
+          Link with target="_blank" + Tabnabbing vulnerability protection
+        </outline-link>
+      </p>
       <p>
         <outline-link link-href="https://outline.phase2tech.com" link-text="Link using properties, including the link text"></outline-link>
       </p>

--- a/src/components/base/outline-link/outline-link.ts
+++ b/src/components/base/outline-link/outline-link.ts
@@ -61,12 +61,23 @@ export class OutlineLink extends OutlineElement {
     return html`${this.linkHref
       ? html` <a
           href=${this.linkHref}
-          rel="${ifDefined(this.linkRel)}"
+          rel="${ifDefined(this.evaluateRelValue())}"
           target="${ifDefined(this.linkTarget)}"
         >
           ${this.linkText ? html`${this.linkText}` : html`<slot></slot>`}
         </a>`
       : html`<slot></slot>`}`;
+  }
+
+  evaluateRelValue() {
+    const relValue = [];
+    if (this.linkRel) relValue.push(this.linkRel);
+    // Protection for Tabnabbing vulnerability
+    // Source: https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing
+    // TLDR: when a link has the attribute target="_blank", always add ref="noreferrer noopener"
+    if (this.linkTarget === '_blank') relValue.push('noreferrer', 'noopener');
+    if (relValue.length > 0) return relValue.join(' ');
+    return;
   }
 }
 


### PR DESCRIPTION
## Description
TIL, when a link has `target="_blank"`, it introduces Tubnabbing vulnerability 🤯 
TLDR: when a link has the attribute `target="_blank"`, always add `ref="noreferrer noopener"`
https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing

This PR fixes that vulnerability.

@TODO: this PR is a great example why Outline components should internally use other low-level Outline components, instead of direct html markup.
e.g. Outline components should use `<outline-link>` instead of using `<a>`, `<outline-image>` instead of `<img>`, etc.
That way, as components improve, edge-cases, accessibility, etc. will only need to get resolved in one place.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In Outline
* Run `yarn serve`
* Open `localhost:8000/dev/link.html`
* Confirm that for `<outline-link>` component with the attribute `target="_blank"`, the `ref="noreferrer noopener"` was automatically added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/326"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

