### PR TITLE
fix: Update container component to respect media queries max-width declarations.

### DIFF
--- a/src/components/base/outline-container/outline-container.css
+++ b/src/components/base/outline-container/outline-container.css
@@ -1,7 +1,6 @@
 :host {
   @apply sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl xxl:max-w-screen-xxl xxxl:max-w-screen-xxxl;
   display: block;
-  max-width: 100%;
   font-family: var(--font-body);
   padding-top: var(
     --outline-container-padding-y,


### PR DESCRIPTION
## Description
The `outline-container` is not working as expected. For some reason, the `max-width` has higher precedence and it overrides the rest of the media queries `max-width` declarations added by Tailwind.   

```CSS
/** src/components/base/outline-container/outline-container.css **/
:host {
  @apply sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl xxl:max-w-screen-xxl xxxl:max-w-screen-xxxl;
  display: block;
  max-width: 100%;

  ...
}
```
Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Visual Testing

![image](https://user-images.githubusercontent.com/1317294/171488964-c653d55a-e745-401b-bc6e-4d0d0b596087.png)
![image](https://user-images.githubusercontent.com/1317294/171489167-8892ed29-605a-42e5-a159-f57683914f3b.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/327"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

