### PR TITLE
fix: Update outline-heading margin bottom styles.

### DIFF
--- a/src/components/base/outline-heading/outline-heading.css
+++ b/src/components/base/outline-heading/outline-heading.css
@@ -1,5 +1,5 @@
 :host {
-  @apply block;
+  @apply mb-4 block;
 }
 
 h1,
@@ -8,7 +8,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply m-0 mb-4;
+  @apply m-0;
 }
 
 /* Default sizes, can be changed with level-size prop */


### PR DESCRIPTION
## Description

The margin-bottom was moved from the `headings` tag selector to the `:host` selector to allow it to be overridden. Currently, with the margin defined on the `heading` tags selectors (see attached code), it is not possible to override it due to the shadow DOM protection.

```CSS
/* file: src/components/base/outline-heading/outline-heading.css */

h1,
h2,
h3,
h4,
h5,
h6 {
  @apply m-0 mb-4;
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Visual Testing

  Heading component with margin-bottom styles on headings tag selector
 
  ![image](https://user-images.githubusercontent.com/1317294/171933910-7a668e24-6d3c-4844-9898-384e0773c298.png)

  Heading component with margin-bottom styles on the `:host` selector.
 
  ![image](https://user-images.githubusercontent.com/1317294/171933700-b274601e-d897-4674-9ce7-96ea03f4ba5f.png)

As you can see in the attached images of above this change does not create any regression.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

