### PR TITLE
Fix for custom icon library resolver and Storybook.

### DIFF
--- a/src/.storybook/main.js
+++ b/src/.storybook/main.js
@@ -12,7 +12,7 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  staticDirs: ['./static'],
+  staticDirs: ['./static', '../assets'],
   stories: [
     // Explicitly order the main documentation.
     './stories/guides/welcome.stories.mdx',

--- a/src/components/base/outline-icon/libraries/library.custom.ts
+++ b/src/components/base/outline-icon/libraries/library.custom.ts
@@ -2,7 +2,7 @@ import { IconLibrary } from '../library';
 
 const library: IconLibrary = {
   name: 'custom',
-  resolver: name => `/dist/assets/svg/custom/${name}.svg`,
+  resolver: name => `./dist/assets/svg/custom/${name}.svg`,
   //mutator: svg => svg.setAttribute('fill', 'currentColor'),
 };
 


### PR DESCRIPTION
## Description

Fix for pathing that allows the production Storybook to work appropriately with icons stored in `src/assets`. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Testing


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/336"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

