### PR TITLE
Fix: update icon of `<outline-icon>`

### DIFF
--- a/src/components/base/outline-icon/outline-icon.ts
+++ b/src/components/base/outline-icon/outline-icon.ts
@@ -140,10 +140,6 @@ export default class OutlineIcon extends OutlineElement {
     }
   }
 
-  handleChange() {
-    this.setIcon();
-  }
-
   render() {
     const hasLabel = typeof this.label === 'string' && this.label.length > 0;
 

--- a/src/components/base/outline-icon/outline-icon.ts
+++ b/src/components/base/outline-icon/outline-icon.ts
@@ -67,6 +67,10 @@ export default class OutlineIcon extends OutlineElement {
     this.sizeIcon();
   }
 
+  updated() {
+    this.setIcon();
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback();
     unwatchIcon(this);


### PR DESCRIPTION
## Description

`<outline-icon>` doesn't update the icon after it is rendered.

## Steps to test:
In Storybook, edit the icon displayed in `outline-icon`, confirm the new icon is displayed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

