### PR TITLE
mobile-screen is from 0 to 767px

### DIFF
--- a/src/components/controllers/mobile-controller.ts
+++ b/src/components/controllers/mobile-controller.ts
@@ -26,7 +26,7 @@ export class MobileController implements ReactiveController {
       // @ts-expect-error shrug
       outline.screens[this.mobileBreakpoint]
     );
-    if (window.innerWidth <= mobileScreen) {
+    if (window.innerWidth < mobileScreen) {
       this.isMobile = true;
     } else {
       this.isMobile = false;


### PR DESCRIPTION
## Description

Currently, `mobile-controller` assume `768px` width is still "mobile".
That is causing issues, because most CSS uses `min-width: 768px`).
This PR updates `mobile-controller` so `767px` is mobile, and `768px` is desktop.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

