### PR TITLE
Fix: Icon alignement in all navs.

### DIFF
--- a/src/components/base/outline-icon/outline-icon.css
+++ b/src/components/base/outline-icon/outline-icon.css
@@ -1,5 +1,10 @@
-:host svg {
-  height: inherit;
-  width: inherit;
-  display: flex;
+:host {
+  .icon {
+    display: flex;
+  }
+
+  svg {
+    height: inherit;
+    width: inherit;
+  }
 }


### PR DESCRIPTION
## Description

The outline had some align problems in safari nav, changing the display: flex rule from the svg to the .icon container, fix this problem

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/341"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
