### PR TITLE
Issue/nt rollup image plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@commitlint/cli": "^13.2.0",
     "@commitlint/config-conventional": "^13.2.0",
     "@open-wc/testing": "^3.0.0-next.2",
+    "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-replace": "^2.4.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import replace from '@rollup/plugin-replace';
 import multi from '@rollup/plugin-multi-entry';
 import typescript from 'rollup-plugin-typescript2';
 import svg from 'rollup-plugin-svg';
-import image from 'rollup-plugin-image';
+import image from '@rollup/plugin-image';
 import json from '@rollup/plugin-json';
 const outline = require('./outline.config');
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import replace from '@rollup/plugin-replace';
 import multi from '@rollup/plugin-multi-entry';
 import typescript from 'rollup-plugin-typescript2';
 import svg from 'rollup-plugin-svg';
+import image from 'rollup-plugin-image;gin-image';
 import json from '@rollup/plugin-json';
 const outline = require('./outline.config');
 
@@ -32,6 +33,7 @@ const sharedConfig = {
     summary(),
     multi(),
     svg(),
+    image()
   ],
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import replace from '@rollup/plugin-replace';
 import multi from '@rollup/plugin-multi-entry';
 import typescript from 'rollup-plugin-typescript2';
 import svg from 'rollup-plugin-svg';
-import image from 'rollup-plugin-image;gin-image';
+import image from 'rollup-plugin-image';
 import json from '@rollup/plugin-json';
 const outline = require('./outline.config');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,6 +1962,14 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
+"@rollup/plugin-image@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-image/-/plugin-image-2.1.1.tgz#898d6b59ac0025d7971ef45640ab330cb0663b0c"
+  integrity sha512-AgP4U85zuQJdUopLUCM+hTf45RepgXeTb8EJsleExVy99dIoYpt3ZlDYJdKmAc2KLkNntCDg6BPJvgJU3uGF+g==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    mini-svg-data-uri "^1.2.3"
+
 "@rollup/plugin-json@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
@@ -2072,7 +2080,7 @@
   resolved "https://registry.yarnpkg.com/@splidejs/splide/-/splide-3.6.12.tgz#9b6bede5c99140fd06754990c91e474374566c30"
   integrity sha512-ggOUAuSxjWuxxL0IQEZcux26KByfKWfYM2HYmvDBdxkXc5evVW+xuECO+3iuciyrJpgcbYTr4hn0cHfbNlYIeA==
 
-"@storybook/addon-a11y@^6.4.22":
+"@storybook/addon-a11y@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.4.22.tgz#df75f1a82c83973c165984e8b0944ceed64c30e9"
   integrity sha512-y125LDx5VR6JmiHB6/0RHWudwhe9QcFXqoAqGqWIj4zRv0kb9AyDPDtWvtDOSImCDXIPRmd8P05xTOnYH0ET3w==
@@ -2094,7 +2102,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-actions@6.4.22", "@storybook/addon-actions@^6.4.22":
+"@storybook/addon-actions@6.4.22", "@storybook/addon-actions@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.4.22.tgz#ec1b4332e76a8021dc0a1375dfd71a0760457588"
   integrity sha512-t2w3iLXFul+R/1ekYxIEzUOZZmvEa7EzUAVAuCHP4i6x0jBnTTZ7sAIUVRaxVREPguH5IqI/2OklYhKanty2Yw==
@@ -2207,7 +2215,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-essentials@^6.4.22":
+"@storybook/addon-essentials@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.4.22.tgz#6981c89e8b315cda7ce93b9bf74e98ca80aec00a"
   integrity sha512-GTv291fqvWq2wzm7MruBvCGuWaCUiuf7Ca3kzbQ/WqWtve7Y/1PDsqRNQLGZrQxkXU0clXCqY1XtkTrtA3WGFQ==
@@ -2227,7 +2235,7 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-links@^6.4.22":
+"@storybook/addon-links@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.4.22.tgz#c0ed9e9ef6505cf1562e1476bbc5064c82dadbe2"
   integrity sha512-OSOyDnTXnmcplJHlXTYUTMkrfpLqxtHp2R69IXfAyI1e8WNDb79mXflrEXDA/RSNEliLkqYwCyYby7gDMGds5Q==
@@ -2430,7 +2438,7 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/builder-webpack5@^6.4.22":
+"@storybook/builder-webpack5@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-6.4.22.tgz#cd10b3b307f4a6f9c474d3b72ba5555055395681"
   integrity sha512-vvQ0HgkIIVz+cmaCXIRor0UFZbGZqh4aV0ISSof60BjdW5ld+R+XCr/bdTU6Zg8b2fL9CXh7/LE6fImnIMpRIA==
@@ -2859,7 +2867,7 @@
     webpack-dev-middleware "^3.7.3"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/manager-webpack5@^6.4.22":
+"@storybook/manager-webpack5@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/manager-webpack5/-/manager-webpack5-6.4.22.tgz#14b6c564692324e25084f699d599cd202659fe21"
   integrity sha512-BMkOMselT4jOn7EQGt748FurM5ewtDfZtOQPCVK8MZX+HYE2AgjNOzm562TYODIxk12Fkhgj3EIz7GGMe1U3RA==
@@ -3063,7 +3071,7 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@storybook/web-components@^6.4.22":
+"@storybook/web-components@~6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/web-components/-/web-components-6.4.22.tgz#4d3e7f539b0a98e315961f9683c44aaa00f4ccd0"
   integrity sha512-6ZF6cZRmsJQXBa6wJyDNVabSLmOvIV1v414lbwO0/WcEztv1JyNRhnLI8d9VqVynenTk68I71riFihsLdPYMBg==
@@ -14162,7 +14170,7 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.13.1.tgz#fae7b5bb9d35fc53dc61cd262df3abb2f6e59022"
   integrity sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==
 
-storybook@^6.4.22:
+storybook@~6.4.22:
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-6.4.22.tgz#d3e7e980b4b48b856b8a743788a1d938c8c6bb50"
   integrity sha512-JWjb7RxPuhWHzesP0NEwu/cbC/ssT3y2u2R25nRs7SIn6XkHDhPUBYPmyosVeIu7Rfl+D2RNkrLDtoAJ/8DNOg==


### PR DESCRIPTION
This PR addresses the occasional need for using images within web components. Currently rollup breaks while bundling any image that you've imported into a component and I've needed to set this up for myself and a couple others. This PR will remedy the need for support moving forward.

Testing: 

- Import an image without the plugin and run `yarn build`
  - Verify that the build breaks
- Import an image with the plugin and run `yarn build`
  - Verify that the build succeeds
  - Profit 🤑 

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

