### PR TITLE
feat(accordion-panel): Updated icon section to a separate template

### DIFF
--- a/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
+++ b/src/components/base/outline-accordion-panel/outline-accordion-panel.ts
@@ -59,10 +59,7 @@ export class OutlineAccordionPanel extends OutlineElement {
             <slot name="heading"> </slot>
           </span>
           <span class="accordion-icon ${isMobile} ${isActive} ${isClean}">
-            <outline-icon
-              name="${this.active ? 'chevron-up' : 'chevron-down'}"
-              size="24px"
-            ></outline-icon>
+            ${this.IconTemplate()}
           </span>
         </button>
       </div>
@@ -76,6 +73,17 @@ export class OutlineAccordionPanel extends OutlineElement {
         <slot></slot>
       </div>
     </div>`;
+  }
+
+  /**
+   * This template allow an easy overwrite when
+   * any component extends this accordion panel
+   */
+  IconTemplate(): TemplateResult {
+    return html`<outline-icon
+      name="${this.active ? 'chevron-up' : 'chevron-down'}"
+      size="24px"
+    ></outline-icon>`;
   }
 
   setActive() {


### PR DESCRIPTION
## Description

This update allow overwrite in an easy way the icon, as usually we extend outline-accordion and create custom styles in a new component but if we want change the icon we should overwrite all the render function, with a template we can just overwrite this template.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Visual Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/344"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

