### PR TITLE
fix: aria-hidden shouldn't be treated as visually hidden

### DIFF
--- a/scripts/styles.js
+++ b/scripts/styles.js
@@ -88,8 +88,6 @@ export default css\`
   box-sizing: inherit;
 }
 /* Apply proper CSS for accessibly hiding elements to each component. */
-:host([aria-hidden="true"]),
-[aria-hidden="true"],
 .visually-hidden {
   position: absolute !important;
   overflow: hidden;


### PR DESCRIPTION
## Description

Although it's often a good idea to target `aria-hidden` in CSS, and make it also visually hidden, there are specific cases where `aria-hidden` is important for hiding things from screen-reader but WITHOUT visually hide the element.
(This fix should also fix the Splide flickering issue when changing slides)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Testing
- [ ] Automated Testing
- [X] Accessibility Testing

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/360"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

