### PR TITLE
fix(actions): Fix for deprecated set-output.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,19 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
 
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
+
       - name: Initialize .npmrc
         run: cp $NPM_CONFIG_USERCONFIG .npmrc
 
@@ -86,6 +99,19 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
+
       - name: Install
         run: yarn install --prefer-offline
 
@@ -113,6 +139,19 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
+
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -144,8 +183,21 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
+
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-18-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -196,11 +248,24 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
           cache: 'yarn'
+
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-18-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -235,11 +300,24 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org/'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
           cache: 'yarn'
+
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-18-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -272,8 +350,21 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
+
+      # @see https://github.com/marketplace/actions/cache
+      # node_modules caching is validated by always running yarn install.
+      # Turborepo cache lives inside node_modules/.cache/turbo
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            storybook-static
+          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-18-yarn-
 
       - name: Install
         run: yarn install --prefer-offline

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -106,7 +106,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -153,7 +153,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -255,7 +255,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -309,7 +309,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         run: cp $NPM_CONFIG_USERCONFIG .npmrc
 
       - name: Install
-        run: yarn install --prefer-offline
+        run: yarn install
         env: 
           NODE_AUTH_TOKEN: ${{ secrets.NPM_GITHUB_PACKAGES }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,12 +70,12 @@ jobs:
         run: cp $NPM_CONFIG_USERCONFIG .npmrc
 
       - name: Install
-        run: yarn install
+        run: yarn install --check-cache
         env: 
           NODE_AUTH_TOKEN: ${{ secrets.NPM_GITHUB_PACKAGES }}
 
       - name: Build Outline
-        run: yarn build
+        run: yarn build --force
 
       - name: Build Storybook
         run: yarn storybook:build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,27 +53,11 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
 
-      # @see https://github.com/marketplace/actions/cache
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-            storybook-static
-          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
-
       - name: Initialize .npmrc
         run: cp $NPM_CONFIG_USERCONFIG .npmrc
 
-      # @todo: Remove this test step.
-      - name: "DEBUG: .npmrc CONTENTS"
-        run: cat .npmrc
-
       - name: Install
-        run: yarn install
+        run: yarn install --prefer-offline
         env: 
           NODE_AUTH_TOKEN: ${{ secrets.NPM_GITHUB_PACKAGES }}
 
@@ -102,24 +86,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      # @see https://github.com/marketplace/actions/cache
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-            storybook-static
-          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
-
-      # @todo: Remove this test step.
-      - name: "DEBUG: YARN VERSION"
-        run: yarn --version
-
-      - name: Install from cache
-        run: yarn install
+      - name: Install
+        run: yarn install --prefer-offline
 
       - name: Build from cache
         run: yarn build
@@ -146,20 +114,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      # @see https://github.com/marketplace/actions/cache
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-            storybook-static
-          key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-yarn-
-
-      - name: Install from cache
-        run: yarn install
+      - name: Install
+        run: yarn install --prefer-offline
 
       - name: Build Outline
         run: yarn build
@@ -192,7 +148,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install
-        run: yarn install
+        run: yarn install --prefer-offline
 
       - name: Build Outline
         run: yarn build
@@ -246,20 +202,8 @@ jobs:
           scope: '@phase2'
           cache: 'yarn'
 
-      # @see https://github.com/marketplace/actions/cache
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-            storybook-static
-          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-16-yarn-
-
-      - name: Install from cache
-        run: yarn install
+      - name: Install
+        run: yarn install --prefer-offline
 
       - name: Build Outline
         run: yarn build
@@ -297,20 +241,8 @@ jobs:
           scope: '@phase2'
           cache: 'yarn'
 
-      # @see https://github.com/marketplace/actions/cache
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-            storybook-static
-          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-16-yarn-
-
-      - name: Install from cache
-        run: yarn install
+      - name: Install
+        run: yarn install --prefer-offline
 
       - name: Build Outline
         run: yarn build
@@ -344,7 +276,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install
-        run: yarn install
+        run: yarn install --prefer-offline
 
       - name: Build Outline
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
@@ -195,9 +195,9 @@ jobs:
           path: |
             node_modules
             storybook-static
-          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-18-yarn-
+            ${{ runner.os }}-node-16-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -248,7 +248,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
@@ -263,9 +263,9 @@ jobs:
           path: |
             node_modules
             storybook-static
-          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-18-yarn-
+            ${{ runner.os }}-node-16-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -300,7 +300,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org/'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
@@ -315,9 +315,9 @@ jobs:
           path: |
             node_modules
             storybook-static
-          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-18-yarn-
+            ${{ runner.os }}-node-16-yarn-
 
       - name: Install
         run: yarn install --prefer-offline
@@ -350,7 +350,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
@@ -362,9 +362,9 @@ jobs:
           path: |
             node_modules
             storybook-static
-          key: ${{ runner.os }}-node-18-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-16-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-18-yarn-
+            ${{ runner.os }}-node-16-yarn-
 
       - name: Install
         run: yarn install --prefer-offline

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -106,7 +106,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -153,7 +153,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -255,7 +255,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -309,7 +309,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={dir::$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: 'yarn'
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -103,10 +100,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+          cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -150,10 +144,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+          cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -195,9 +186,10 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
 
       - name: Install
         run: yarn install
@@ -252,10 +244,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+          cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -306,10 +295,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           # Defaults to the user or organization that owns the workflow file
           scope: '@phase2'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+          cache: 'yarn'
 
       # @see https://github.com/marketplace/actions/cache
       - uses: actions/cache@v3
@@ -352,9 +338,10 @@ jobs:
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
 
       - name: Install
         run: yarn install


### PR DESCRIPTION
## Description

Fix for warnings found at https://github.com/phase2/outline/actions/runs/3472209866 an other Action runs.

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<a href="https://gitpod.io/#https://github.com/phase2/outline/pull/362"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

