### PR TITLE
Refactor css variables for all components to reflect ADR.

### DIFF
--- a/packages/outline-admin-links/README.md
+++ b/packages/outline-admin-links/README.md
@@ -16,10 +16,10 @@ The Outline Admin Links component
 
 ## CSS Custom Properties
 
-| Property                       | Description                                      |
-|--------------------------------|--------------------------------------------------|
-| `--outline-admin-links-bg`     | default: The default background color for the admin links. |
-| `--outline-admin-links-color`  | default: The default text color for the admin links. |
-| `--outline-admin-links-link-x` | spacing: The horizontal padding for the individual admin links. |
-| `--outline-admin-links-link-y` | spacing: The vertical padding for the individual admin links. |
-| `--outline-admin-links-y`      | spacing: The vertical spacing for the admin links group. |
+| Property                                | Description                                      |
+|-----------------------------------------|--------------------------------------------------|
+| `--outline-admin-links--bg`             | default: The default background color for the admin links. |
+| `--outline-admin-links--color`          | default: The default text color for the admin links. |
+| `--outline-admin-links--link-spacing-x` | spacing: The horizontal padding for the individual admin links. |
+| `--outline-admin-links--link-spacing-y` | spacing: The vertical padding for the individual admin links. |
+| `--outline-admin-links--spacing-y`      | spacing: The vertical spacing for the admin links group. |

--- a/packages/outline-admin-links/src/css-variables/vars-admin-links.css
+++ b/packages/outline-admin-links/src/css-variables/vars-admin-links.css
@@ -1,21 +1,20 @@
 /*
 Default CSS Variables for `outline-admin-links`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-admin-links` styling can be found in 
-`outline-admin-links.ts` delcared with the `@cssprop` annotations.
 */
 
---outline-admin-links--default-color-default: var(--outline-gray-600);
---outline-admin-links--default-color-hover: var(--outline-soft-black);
---outline-admin-links--default-color-focus: var(--outline-soft-black);
---outline-admin-links--default-color-active: var(--outline-white);
---outline-admin-links--default-bg-default: var(--outline-gray-100);
---outline-admin-links--default-bg-hover: var(--outline-gray-300);
---outline-admin-links--default-bg-focus: var(--outline-gray-300);
---outline-admin-links--default-bg-active: var(--outline-blue-600);
---outline-admin-links--default-y-spacing: var(--spacing-4);
---outline-admin-links--default-link-y-spacing: var(--spacing-4);
---outline-admin-links--default-link-x-spacing: var(--spacing-6);
+:host {
+  --outline-admin-links--color--computed: var(--outline-admin-links--color, var(--outline-gray-600));
+  --outline-admin-links--color-hover--computed: var(--outline-admin-links--color-hover, var(--outline-soft-black));
+  --outline-admin-links--color-focus--computed: var(--outline-admin-links--color-focus, var(--outline-soft-black));
+  --outline-admin-links--color-active--computed: var(--outline-admin-links--color-active,var( --outline-white));
+  --outline-admin-links--bg--computed: var(--outline-admin-links--bg, var(--outline-gray-100));
+  --outline-admin-links--bg-hover--computed: var(--outline-admin-links--bg-hover,var( --outline-gray-300));
+  --outline-admin-links--bg-focus--computed: var(--outline-admin-links--bg-focus,var( --outline-gray-300));
+  --outline-admin-links--bg-active--computed: var(--outline-admin-links--bg-active, var(--outline-blue-600));
+  --outline-admin-links--spacing-y--computed: var(--outline-admin-links--spacing-y, var(--spacing-4));
+  --outline-admin-links--link-spacing-y--computed: var(--outline-admin-links--link-spacing-y, var(--spacing-4));
+  --outline-admin-links--link-spacing-x--computed: var(--outline-admin-links--link-spacing-x, var(--spacing-6));
+}

--- a/packages/outline-admin-links/src/outline-admin-links.css
+++ b/packages/outline-admin-links/src/outline-admin-links.css
@@ -49,14 +49,12 @@ a {
     height: 100%;
     content: '';
     transform: translate(-50%, -50%);
-    border: solid 2px
-      var(--outline-admin-links--color-hover--computed);
+    border: solid 2px var(--outline-admin-links--color-hover--computed);
     border-radius: 0.25rem;
   }
 
   &.is-active {
-    outline: solid 2px
-      var(--outline-admin-links--color-hover--computed);
+    outline: solid 2px var(--outline-admin-links--color-hover--computed);
     background: var(--outline-admin-links--bg-active--computed);
     color: var(--outline-admin-links--color-active--computed);
     z-index: 1;

--- a/packages/outline-admin-links/src/outline-admin-links.css
+++ b/packages/outline-admin-links/src/outline-admin-links.css
@@ -1,12 +1,8 @@
+@import './css-variables/vars-admin-links.css';
+
 .links {
-  padding-top: var(
-    --outline-admin-links-y-spacing,
-    var(--outline-admin-links--default-y-spacing)
-  );
-  padding-bottom: var(
-    --outline-admin-links-y-spacing,
-    var(--outline-admin-links--default-y-spacing)
-  );
+  padding-top: var(--outline-admin-links--spacing-y--computed);
+  padding-bottom: var(--outline-admin-links--spacing-y--computed);
 }
 
 ul {
@@ -25,53 +21,23 @@ li {
 a {
   position: relative;
   text-decoration: none;
-  padding-top: var(
-    --outline-admin-links-link-y-spacing,
-    var(--outline-admin-links--default-link-y-spacing)
-  );
-  padding-bottom: var(
-    --outline-admin-links-link-y-spacing,
-    var(--outline-admin-links--default-link-y-spacing)
-  );
-  padding-left: var(
-    --outline-admin-links-link-x-spacing,
-    var(--outline-admin-links--default-link-x-spacing)
-  );
-  padding-right: var(
-    --outline-admin-links-link-x-spacing,
-    var(--outline-admin-links--default-link-x-spacing)
-  );
-  background: var(
-    --outline-admin-links-bg-default,
-    var(--outline-admin-links--default-bg-default)
-  );
-  color: var(
-    --outline-admin-links-color-default,
-    var(--outline-admin-links--default-color-default)
-  );
+  padding-top: var(--outline-admin-links--link-spacing-y--computed);
+  padding-bottom: var(--outline-admin-links--link-spacing-y--computed);
+  padding-left: var(--outline-admin-links--link-spacing-x--computed);
+  padding-right: var(--outline-admin-links--link-spacing-x--computed);
+  background: var(--outline-admin-links--bg--computed);
+  color: var(--outline-admin-links--color--computed);
 
   &:hover {
     outline: none;
-    background: var(
-      --outline-admin-links-bg-hover,
-      var(--outline-admin-links--default-bg-hover)
-    );
-    color: var(
-      --outline-admin-links-color-hover,
-      var(--outline-admin-links--default-color-hover)
-    );
+    background: var(--outline-admin-links--bg-hover--computed);
+    color: var(--outline-admin-links--color-hover--computed);
   }
 
   &:focus {
     outline: none;
-    background: var(
-      --outline-admin-links-bg-focus,
-      var(--outline-admin-links--default-bg-focus)
-    );
-    color: var(
-      --outline-admin-links-color-focus,
-      var(--outline-admin-links--default-color-focus)
-    );
+    background: var(--outline-admin-links--bg-focus--computed);
+    color: var(--outline-admin-links--color-focus--computed);
   }
 
   &:not(.is-active):hover::before,
@@ -84,27 +50,15 @@ a {
     content: '';
     transform: translate(-50%, -50%);
     border: solid 2px
-      var(
-        --outline-admin-links-color-hover,
-        var(--outline-admin-links--default-color-hover)
-      );
+      var(--outline-admin-links--color-hover--computed);
     border-radius: 0.25rem;
   }
 
   &.is-active {
     outline: solid 2px
-      var(
-        --outline-admin-links-color-hover,
-        var(--outline-admin-links--default-color-hover)
-      );
-    background: var(
-      --outline-admin-links-bg-active,
-      var(--outline-admin-links--default-bg-active)
-    );
-    color: var(
-      --outline-admin-links-color-active,
-      var(--outline-admin-links--default-color-active)
-    );
+      var(--outline-admin-links--color-hover--computed);
+    background: var(--outline-admin-links--bg-active--computed);
+    color: var(--outline-admin-links--color-active--computed);
     z-index: 1;
 
     &:hover,

--- a/packages/outline-admin-links/src/outline-admin-links.ts
+++ b/packages/outline-admin-links/src/outline-admin-links.ts
@@ -1,7 +1,6 @@
 import { CSSResultGroup, TemplateResult, html } from 'lit';
 import { OutlineElement, SlotController } from '@phase2/outline-core';
 import { customElement } from 'lit/decorators.js';
-import componentVars from './css-variables/vars-admin-links.css.lit';
 import componentStyles from './outline-admin-links.css.lit';
 
 /**
@@ -9,17 +8,17 @@ import componentStyles from './outline-admin-links.css.lit';
  * @element outline-admin-links
  * @extends OutlineElement
  * @slot - The default slot for this element.
- * @cssprop --outline-admin-links-color-default: The default text color for the admin links.
- * @cssprop --outline-admin-links-color-hover: The hover text color for the admin links.
- * @cssprop --outline-admin-links-color-focus: The focus text color for the admin links.
- * @cssprop --outline-admin-links-color-active: The active text color for the admin links.
- * @cssprop --outline-admin-links-bg-default: The default background color for the admin links.
- * @cssprop --outline-admin-links-bg-hover: The hover background color for the admin links.
- * @cssprop --outline-admin-links-bg-focus: The focus background color for the admin links.
- * @cssprop --outline-admin-links-bg-active: The active background color for the admin links.
- * @cssprop --outline-admin-links-y-spacing: The vertical spacing for the admin links group.
- * @cssprop --outline-admin-links-link-y-spacing: The vertical padding for the individual admin links.
- * @cssprop --outline-admin-links-link-x-spacing: The horizontal padding for the individual admin links.
+ * @cssprop --outline-admin-links--color: The default text color for the admin links.
+ * @cssprop --outline-admin-links--color-hover: The hover text color for the admin links.
+ * @cssprop --outline-admin-links--color-focus: The focus text color for the admin links.
+ * @cssprop --outline-admin-links--color-active: The active text color for the admin links.
+ * @cssprop --outline-admin-links--bg-default: The default background color for the admin links.
+ * @cssprop --outline-admin-links--bg-hover: The hover background color for the admin links.
+ * @cssprop --outline-admin-links--bg-focus: The focus background color for the admin links.
+ * @cssprop --outline-admin-links--bg-active: The active background color for the admin links.
+ * @cssprop --outline-admin-links--spacing-y: The vertical spacing for the admin links group.
+ * @cssprop --outline-admin-links--link-spacing-y: The vertical padding for the individual admin links.
+ * @cssprop --outline-admin-links--link-spacing=x: The horizontal padding for the individual admin links.
  * @todo: Ensure this component is more mobile friendly.
  */
 @customElement('outline-admin-links')
@@ -28,7 +27,7 @@ export class OutlineAdminLinks extends OutlineElement {
     this, // This, the host element.
     true // To shift or not to shift LightDom nodes to ShadowDOM.
   );
-  static styles: CSSResultGroup = [componentVars, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
 
   render(): TemplateResult {
     return html`

--- a/packages/outline-admin-links/src/outline-admin-links.ts
+++ b/packages/outline-admin-links/src/outline-admin-links.ts
@@ -18,7 +18,7 @@ import componentStyles from './outline-admin-links.css.lit';
  * @cssprop --outline-admin-links--bg-active: The active background color for the admin links.
  * @cssprop --outline-admin-links--spacing-y: The vertical spacing for the admin links group.
  * @cssprop --outline-admin-links--link-spacing-y: The vertical padding for the individual admin links.
- * @cssprop --outline-admin-links--link-spacing=x: The horizontal padding for the individual admin links.
+ * @cssprop --outline-admin-links--link-spacing-x: The horizontal padding for the individual admin links.
  * @todo: Ensure this component is more mobile friendly.
  */
 @customElement('outline-admin-links')

--- a/packages/outline-alert/README.md
+++ b/packages/outline-alert/README.md
@@ -20,9 +20,9 @@ The Outline Alert component
 
 ## CSS Custom Properties
 
-| Property                  | Description                                      |
-|---------------------------|--------------------------------------------------|
-| `--outline-alert-error`   | background: The background color for the error alert. |
-| `--outline-alert-info`    | background: The background color for the info alert. |
-| `--outline-alert-success` | background: The background color for the success alert. |
-| `--outline-alert-warning` | background: The background color for the warning alert. |
+| Property                   | Description                                      |
+|----------------------------|--------------------------------------------------|
+| `--outline-alert--error`   | background: The background color for the error alert. |
+| `--outline-alert--info`    | background: The background color for the info alert. |
+| `--outline-alert--success` | background: The background color for the success alert. |
+| `--outline-alert--warning` | background: The background color for the warning alert. |

--- a/packages/outline-alert/src/css-variables/vars-alert.css
+++ b/packages/outline-alert/src/css-variables/vars-alert.css
@@ -1,25 +1,24 @@
 /*
 Default CSS Variables for `outline-alert`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-alert` styling can be found in 
-`outline-alert.ts` delcared with the `@cssprop` annotations.
 */
 
---outline-alert--default-info-background: var(--outline-white);
---outline-alert--default-info-text: var(--status-info);
---outline-alert--default-info-border: var(--status-info);
+:host {
+  --outline-alert--info-background--computed: var(--outline-alert--info-background, var(--outline-white));
+  --outline-alert--info-text--computed: var(--outline-alert--info-text,var( --status-info));
+  --outline-alert--info-border--computed: var(--outline-alert--info-border, var(--status-info));
 
---outline-alert--default-success-background: var(--outline-white);
---outline-alert--default-success-text: var(--status-success);
---outline-alert--default-success-border: var(--status-success);
+  --outline-alert--success-background--computed: var(--outline-alert--success-background, var(--outline-white));
+  --outline-alert--success-text--computed: var(--outline-alert--success-text, var(--status-success));
+  --outline-alert--success-border--computed: var(--outline-alert--success-border, var(--status-success));
 
---outline-alert--default-warning-background: var(--outline-white);
---outline-alert--default-warning-text: var(--status-warning);
---outline-alert--default-warning-border: var(--status-warning);
+  --outline-alert--warning-background--computed: var(--outline-alert--warning-background, var(--outline-white));
+  --outline-alert--warning-text--computed: var(--outline-alert--warning-text, var(--status-warning));
+  --outline-alert--warning-border--computed: var(--outline-alert--warning-border, var(--status-warning));
 
---outline-alert--default-error-background: var(--outline-white);
---outline-alert--default-error-text: var(--status-error);
---outline-alert--default-error-border: var(--status-error);
+  --outline-alert--error-background--computed: var(--outline-alert--error-background, var(--outline-white));
+  --outline-alert--error-text--computed: var(--outline-alert--error-text, var(--status-error));
+  --outline-alert--error-border--computed: var(--outline-alert--error-border, var(--status-error));
+}

--- a/packages/outline-alert/src/outline-alert.css
+++ b/packages/outline-alert/src/outline-alert.css
@@ -1,3 +1,5 @@
+@import './css-variables/vars-alert.css';
+
 .alert-body {
   display: block;
   border-width: 0;
@@ -14,61 +16,25 @@
 }
 
 :host([statusType='info']) .alert-body {
-  background-color: var(
-    --outline-alert-info-background,
-    var(--outline-alert--default-info-background)
-  );
-  border-color: var(
-    --outline-alert-info-border,
-    var(--outline-alert--default-info-border)
-  );
-  color: var(
-    --outline-alert-info-text,
-    var(--outline-alert--default-info-text)
-  );
+  background-color: var(--outline-alert--info-background--computed);
+  border-color: var(--outline-alert--info-border--computed);
+  color: var(--outline-alert--info-text--computed);
 }
 
 :host([statusType='warning']) .alert-body {
-  background-color: var(
-    --outline-alert-warning-background,
-    var(--outline-alert--default-warning-background)
-  );
-  border-color: var(
-    --outline-alert-warning-border,
-    var(--outline-alert--default-warning-border)
-  );
-  color: var(
-    --outline-alert-warning-text,
-    var(--outline-alert--default-warning-text)
-  );
+  background-color: var(--outline-alert--warning-background--computed);
+  border-color: var(--outline-alert--warning-border--computed);
+  color: var(--outline-alert--warning-text--computed);
 }
 
 :host([statusType='error']) .alert-body {
-  background-color: var(
-    --outline-alert-error-background,
-    var(--outline-alert--default-error-background)
-  );
-  border-color: var(
-    --outline-alert-error-border,
-    var(--outline-alert--default-error-border)
-  );
-  color: var(
-    --outline-alert-error-text,
-    var(--outline-alert--default-error-text)
-  );
+  background-color: var(--outline-alert--error-background--computed);
+  border-color: var(--outline-alert--error-border--computed);
+  color: var(--outline-alert--error-text--computed);
 }
 
 :host([statusType='success']) .alert-body {
-  background-color: var(
-    --outline-alert-success-background,
-    var(--outline-alert--default-success-background)
-  );
-  border-color: var(
-    --outline-alert-success-border,
-    var(--outline-alert--default-success-border)
-  );
-  color: var(
-    --outline-alert-success-text,
-    var(--outline-alert--default-success-text)
-  );
+  background-color: var(--outline-alert--success-background--computed);
+  border-color: var(--outline-alert--success-border--computed);
+  color: var(--outline-alert--success-text--computed);
 }

--- a/packages/outline-alert/src/outline-alert.ts
+++ b/packages/outline-alert/src/outline-alert.ts
@@ -2,7 +2,6 @@ import { html, TemplateResult, CSSResultGroup } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { OutlineElement } from '@phase2/outline-core';
-import componentVars from './css-variables/vars-alert.css.lit';
 import componentStyles from './outline-alert.css.lit';
 
 export const alertSizes = ['small', 'large'] as const;
@@ -31,18 +30,18 @@ export interface OutlineAlertInterface extends HTMLElement {
  * @extends OutlineElement
  * @slot default - The alert contents.
  * @slot header - The header in the alert.
- * @cssprop --outline-alert-info-background: The background color for the info alert.
- * @cssprop --outline-alert-info-text: The text color for the info alert.
- * @cssprop --outline-alert-info-border: The border color for the info alert.
- * @cssprop --outline-alert-success-background: The background color for the success alert.
- * @cssprop --outline-alert-success-text: The text color for the success alert.
- * @cssprop --outline-alert-success-border: The border color for the success alert.
- * @cssprop --outline-alert-warning-background: The background color for the warning alert.
- * @cssprop --outline-alert-warning-text: The text color for the warning alert.
- * @cssprop --outline-alert-warning-border: The border color for the warning alert.
- * @cssprop --outline-alert-error-background: The background color for the error alert.
- * @cssprop --outline-alert-error-text: The text color for the error alert.
- * @cssprop --outline-alert-error-border: The border color for the error alert.
+ * @cssprop --outline-alert--info-background: The background color for the info alert.
+ * @cssprop --outline-alert--info-text: The text color for the info alert.
+ * @cssprop --outline-alert--info-border: The border color for the info alert.
+ * @cssprop --outline-alert--success-background: The background color for the success alert.
+ * @cssprop --outline-alert--success-text: The text color for the success alert.
+ * @cssprop --outline-alert--success-border: The border color for the success alert.
+ * @cssprop --outline-alert--warning-background: The background color for the warning alert.
+ * @cssprop --outline-alert--warning-text: The text color for the warning alert.
+ * @cssprop --outline-alert--warning-border: The border color for the warning alert.
+ * @cssprop --outline-alert--error-background: The background color for the error alert.
+ * @cssprop --outline-alert--error-text: The text color for the error alert.
+ * @cssprop --outline-alert--error-border: The border color for the error alert.
  * @todo: Make the alert styling more flexible.
  */
 @customElement('outline-alert')
@@ -50,7 +49,7 @@ export class OutlineAlert
   extends OutlineElement
   implements OutlineAlertInterface
 {
-  static styles: CSSResultGroup = [componentVars, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
 
   @property({ type: String })
   statusType: AlertStatusType = 'info';

--- a/packages/outline-breadcrumbs/README.md
+++ b/packages/outline-breadcrumbs/README.md
@@ -17,10 +17,10 @@ The Outline  Breadcrumbs component
 
 ## CSS Custom Properties
 
-| Property                               | Description                                      |
-|----------------------------------------|--------------------------------------------------|
-| `--outline-breadcrumb-bg`              | color: The background color for the breadcrumbs. |
-| `--outline-breadcrumb-link-color`      | default: The default link color for the breadcrumbs. |
-| `--outline-breadcrumb-link-decoration` | default: The default text decoration for the breadcrumb links. |
-| `--outline-breadcrumb-separator`       | spacing: The spacing between the breadcrumbs.    |
-| `--outline-breadcrumb-text-color`      | default: The default text color for the breadcrumbs. |
+| Property                                | Description                                      |
+|-----------------------------------------|--------------------------------------------------|
+| `--outline-breadcrumb--bg`              | color: The background color for the breadcrumbs. |
+| `--outline-breadcrumb--link-color`      | default: The default link color for the breadcrumbs. |
+| `--outline-breadcrumb--link-decoration` | default: The default text decoration for the breadcrumb links. |
+| `--outline-breadcrumb--separator`       | spacing: The spacing between the breadcrumbs.    |
+| `--outline-breadcrumb--text-color`      | default: The default text color for the breadcrumbs. |

--- a/packages/outline-breadcrumbs/src/css-variables/vars-breadcrumbs.css
+++ b/packages/outline-breadcrumbs/src/css-variables/vars-breadcrumbs.css
@@ -1,20 +1,22 @@
 /*
 Default CSS Variables for `outline-breadcrumb`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-breadcrumb` styling can be found in 
+The variables used to override the default
+`outline-breadcrumb` styling can be found in
 `outline-breadcrumb.ts` delcared with the `@cssprop` annotations.
 */
 
---outline-breadcrumb--default-text-color-default: var(--outline-gray-100);
---outline-breadcrumb--default-link-color-default: var(--outline-white);
---outline-breadcrumb--default-link-color-hover: var(--outline-gray-300);
---outline-breadcrumb--default-link-color-focus: var(--outline-gray-300);
---outline-breadcrumb--default-link-decoration-default: none;
---outline-breadcrumb--default-link-decoration-hover: underline;
---outline-breadcrumb--default-link-decoration-focus: underline;
---outline-breadcrumb--default-bg-color: var(--outline-blue-600);
---outline-breadcrumb--default-bg-padding: var(--spacing-4) var(--spacing-4);
---outline-breadcrumb--default-separator-spacing: var(--spacing-2);
+:host {
+  --outline-breadcrumb--text-color--computed: var(--outline-breadcrumb--text-color, var(--outline-gray-100));
+  --outline-breadcrumb--link-color--computed: var(--outline-breadcrumb--link-color, var(--outline-white));
+  --outline-breadcrumb--link-color-hover--computed: var(--outline-breadcrumb--link-color-hover, var(--outline-gray-300));
+  --outline-breadcrumb--link-color-focus--computed: var(--outline-breadcrumb--link-color-focus, var(--outline-gray-300));
+  --outline-breadcrumb--link-decoration--computed: var(--outline-breadcrumb--link-decoration, none);
+  --outline-breadcrumb--link-decoration-hover--computed: var(--outline-breadcrumb--link-decoration-hover, underline);
+  --outline-breadcrumb--link-decoration-focus--computed: var(--outline-breadcrumb--link-decoration-focus, underline);
+  --outline-breadcrumb--bg-color--computed: var(--outline-breadcrumb--bg-color, var(--outline-blue-600));
+  --outline-breadcrumb--bg-padding--computed: var(--outline-breadcrumb--bg-padding, var(--spacing-4) var(--spacing-4));
+  --outline-breadcrumb--separator-spacing--computed: var(--outline-breadcrumb--separator-spacing, var(--spacing-2));
+}

--- a/packages/outline-breadcrumbs/src/outline-breadcrumbs.css
+++ b/packages/outline-breadcrumbs/src/outline-breadcrumbs.css
@@ -1,63 +1,32 @@
+@import './css-variables/vars-breadcrumbs.css';
+
 .outline-breadcrumbs {
-  color: var(
-    --outline-breadcrumb-text-color-default,
-    var(--outline-breadcrumb--default-text-color-default)
-  );
-  background: var(
-    --outline-breadcrumb-bg-color,
-    var(--outline-breadcrumb--default-bg-color)
-  );
-  padding: var(
-    --outline-breadcrumb-bg-padding,
-    var(--outline-breadcrumb--default-bg-padding)
-  );
+  color: var(--outline-breadcrumb--text-color--computed);
+  background: var(--outline-breadcrumb--bg-color--computed);
+  padding: var(--outline-breadcrumb--bg-padding--computed);
 }
 
 a,
 ::slotted(a) {
   @apply font-body transition-colors duration-300;
-  text-decoration: var(
-    --outline-breadcrumb-link-decoration-default,
-    var(--outline-breadcrumb--default-link-decoration-default)
-  );
-  color: var(
-    --outline-breadcrumb-link-color-default,
-    var(--outline-breadcrumb--default-link-color-default)
-  );
+  text-decoration: var(--outline-breadcrumb--link-decoration--computed);
+  color: var(--outline-breadcrumb--link-color--computed);
 }
 
 a:hover,
 ::slotted(a:hover) {
-  text-decoration: var(
-    --outline-breadcrumb-link-decoration-hover,
-    var(--outline-breadcrumb--default-link-decoration-hover)
-  );
-  color: var(
-    --outline-breadcrumb-link-color-hover,
-    var(--outline-breadcrumb--default-link-color-hover)
-  );
+  text-decoration: var(--outline-breadcrumb--link-decoration-hover--computed);
+  color: var(--outline-breadcrumb--link-color-hover--computed);
 }
 
 a:focus,
 ::slotted(a:focus) {
-  text-decoration: var(
-    --outline-breadcrumb-link-decoration-focus,
-    var(--outline-breadcrumb--default-link-decoration-focus)
-  );
+  text-decoration: var(--outline-breadcrumb--link-decoration-focus--computed);
   outline: none;
-  color: var(
-    --outline-breadcrumb-link-color-focus,
-    var(--outline-breadcrumb--default-link-color-focus)
-  );
+  color: var(--outline-breadcrumb--link-color-focus--computed);
 }
 
 .separator {
-  margin-left: var(
-    --outline-breadcrumb-separator-spacing,
-    var(--outline-breadcrumb--default-separator-spacing)
-  );
-  margin-right: var(
-    --outline-breadcrumb-separator-spacing,
-    var(--outline-breadcrumb--default-separator-spacing)
-  );
+  margin-left: var(--outline-breadcrumb--separator-spacing--computed);
+  margin-right: var(--outline-breadcrumb--separator-spacing--computed);
 }

--- a/packages/outline-breadcrumbs/src/outline-breadcrumbs.ts
+++ b/packages/outline-breadcrumbs/src/outline-breadcrumbs.ts
@@ -2,7 +2,6 @@
 import { OutlineElement, SlotController } from '@phase2/outline-core';
 import { CSSResultGroup, html, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import componentVars from './css-variables/vars-breadcrumbs.css.lit';
 import componentStyles from './outline-breadcrumbs.css.lit';
 import '@phase2/outline-container';
 
@@ -11,16 +10,16 @@ import '@phase2/outline-container';
  * @element outline-breadcrumbs
  * @extends OutlineElement
  * @slot - The default slot for this element.
- * @cssprop --outline-breadcrumb-text-color-default: The default text color for the breadcrumbs.
- * @cssprop --outline-breadcrumb-link-color-default: The default link color for the breadcrumbs.
- * @cssprop --outline-breadcrumb-link-color-hover: The hover link color for the breadcrumbs.
- * @cssprop --outline-breadcrumb-link-color-focus: The focus link color for the breadcrumbs.
- * @cssprop --outline-breadcrumb-link-decoration-default: The default text decoration for the breadcrumb links.
- * @cssprop --outline-breadcrumb-link-decoration-hover: The hover text decoration for the breadcrumb links.
- * @cssprop --outline-breadcrumb-link-decoration-focus: The focus text decoration for the breadcrumb links.
- * @cssprop --outline-breadcrumb-bg-color: The background color for the breadcrumbs.
- * @cssprop --outline-breadcrumb-bg-padding: The padding for the breadcrumbs.
- * @cssprop --outline-breadcrumb-separator-spacing: The spacing between the breadcrumbs.
+ * @cssprop --outline-breadcrumb--text-color: The default text color for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--link-color: The default link color for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--link-color-hover: The hover link color for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--link-color-focus: The focus link color for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--link-decoration: The default text decoration for the breadcrumb links.
+ * @cssprop --outline-breadcrumb--link-decoration-hover: The hover text decoration for the breadcrumb links.
+ * @cssprop --outline-breadcrumb--link-decoration-focus: The focus text decoration for the breadcrumb links.
+ * @cssprop --outline-breadcrumb--bg-color: The background color for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--bg-padding: The padding for the breadcrumbs.
+ * @cssprop --outline-breadcrumb--separator-spacing: The spacing between the breadcrumbs.
  *
  * @todo - Add support for separator icons in slots. This would need optionally a home icon, and a separator icon.
  */
@@ -31,7 +30,7 @@ export class OutlineBreadcrumbs extends OutlineElement {
     this, // This, the host element.
     true // To shift or not to shift LightDom nodes to ShadowDOM.
   );
-  static styles: CSSResultGroup = [componentVars, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
 
   firstUpdated(): void {
     const breadcrumbItems: NodeListOf<HTMLSpanElement> =

--- a/packages/outline-button/src/css-variables/vars-default.css
+++ b/packages/outline-button/src/css-variables/vars-default.css
@@ -1,22 +1,23 @@
 /*
 Default CSS Variables for `outline-button`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-button` styling can be found in 
+The variables used to override the default
+`outline-button` styling can be found in
 `outline-button.ts` delcared with the `@cssprop` annotations.
 */
 
-/* 
---outline-btn-weight
---outline-btn-family
---outline-btn-padding
---outline-btn-border-radius
+/*
+--outline-button--family
+--outline-button--weight
+--outline-button--padding
+--outline-button--radius
 */
 
---outline-button--default-family: var(--ff-body);
---outline-button--default-weight: var(--fw-semibold);
---outline-button--default-padding: var(--spacing-2) var(--spacing-4);
---outline-button--default-radius: var(--spacing-2);
-
+:host {
+  --outline-button--family--computed: var(--outline-button--family, var(--ff-body));
+  --outline-button--weight--computed: var(--outline-button--weight, var(--fw-semibold));
+  --outline-button--padding--computed: var(--outline-button--padding, var(--spacing-2) var(--spacing-4));
+  --outline-button--radius--computed: var(--outline-button--radius, var(--spacing-2));
+}

--- a/packages/outline-button/src/css-variables/vars-link.css
+++ b/packages/outline-button/src/css-variables/vars-link.css
@@ -1,78 +1,84 @@
 /*
 Default CSS Variables for the `outline-button` link variant.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-button` styling can be found in 
+The variables used to override the default
+`outline-button` styling can be found in
 `outline-button.ts` delcared with the `@cssprop` annotations.
 */
 
-/* 
---outline--button--link-padding
---outline--button--link-radius
---outline--button--link-bg-color-default
---outline--button--link-text-color-default
---outline--button--link-decoration-default
---outline--button--link-weight-default
---outline--button--link-ring-default
---outline--button--link-bg-color-hover
---outline--button--link-text-color-hover
---outline--button--link-decoration-hover
---outline--button--link-weight-hover
---outline--button--link-ring-hover
---outline--button--link-bg-color-focus
---outline--button--link-text-color-focus
---outline--button--link-decoration-focus
---outline--button--link-weight-focus
---outline--button--link-ring-focus
---outline--button--link--disabled-bg-color
---outline--button--link--disabled-text-color
---outline--button--link--disabled-decoration
---outline--button--link--disabled-weight
---outline--button--link--disabled-ring
---outline--button--link--disabled-bg-color-focus
---outline--button--link--disabled-text-color-focus
---outline--button--link--disabled-decoration-focus
---outline--button--link--disabled-weight-focus
---outline--button--link--disabled-ring-focus
+/*
+--outline-button--link-padding
+--outline-button--link-radius
+--outline-button--link-bg-color
+--outline-button--link-text-color
+--outline-button--link-decoration
+--outline-button--link-weight
+--outline-button--link-ring
+
+--outline-button--link-bg-color-hover
+--outline-button--link-text-color-hover
+--outline-button--link-decoration-hover
+--outline-button--link-weight-hover
+--outline-button--link-ring-hover
+
+--outline-button--link-bg-color-focus
+--outline-button--link-text-color-focus
+--outline-button--link-decoration-focus
+--outline-button--link-weight-focus
+--outline-button--link-ring-focus
+
+--outline-button--link-disabled-bg-color
+--outline-button--link-disabled-text-color
+--outline-button--link-disabled-decoration
+--outline-button--link-disabled-weight
+--outline-button--link-disabled-ring
+--outline-button--link-disabled-bg-color-focus
+--outline-button--link-disabled-text-color-focus
+--outline-button--link-disabled-decoration-focus
+--outline-button--link-disabled-weight-focus
+--outline-button--link-disabled-ring-focus
 */
 
-/* Link Button(s) */
---outline-button--default--link-padding: var(--outline-button--default-padding);
---outline-button--default--link-radius: var(--outline-button--default-radius);
+:host {
 
-/* Link Button(s) - Default */
---outline-button--default--link-bg-color-default: var(--outline-transparent);
---outline-button--default--link-text-color-default: var(--outline--link-default-color-default);
---outline-button--default--link-decoration-default: none;
---outline-button--default--link-weight-default: var(--outline-button--default-weight);
---outline-button--default--link-ring-default: none;
+  /* Link Button(s) */
+  --outline-button--link-padding--computed: var(--outline-button--link-padding, var(--outline-button--padding--computed));
+  --outline-button--link-radius--computed: var(--outline-button--link-radius, var(--outline-button--radius--computed));
 
-/* Link Button(s) - Hover */
---outline-button--default--link-bg-color-hover: var(--outline-transparent);
---outline-button--default--link-text-color-hover: var(--outline--link-default-color-hover);
---outline-button--default--link-decoration-hover: underline;
---outline-button--default--link-weight-hover: var(--outline-button--default-weight);
---outline-button--default--link-ring-hover: none;
+  /* Link Button(s) - Default */
+  --outline-button--link-bg-color--computed: var(--outline-button--link-bg-color, var(--outline-transparent));
+  --outline-button--link-color--computed: var(--outline-button--link-color, var(--outline-link--color--computed));
+  --outline-button--link-decoration--computed: var(--outline-button--link-decoration,  var(--outline-link--decoration--computed));
+  --outline-button--link-weight--computed: var(--outline-button--link-weight, var(--outline-button--weight--computed));
+  --outline-button--link-ring--computed: var(--outline-button--link-ring, none);
 
-/* Link Button(s) - Focus */
---outline-button--default--link-bg-color-focus: var(--outline-transparent);
---outline-button--default--link-text-color-focus: var(--outline--link-default-color-focus);
---outline-button--default--link-decoration-focus: none;
---outline-button--default--link-weight-focus: var(--outline-button--default-weight);
---outline-button--default--link-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-500);
+  /* Link Button(s) - Hover */
+  --outline-button--link-bg-color-hover--computed: var(--outline-button--link-bg-color-hover, var(--outline-transparent));
+  --outline-button--link-color-hover--computed: var(--outline-button--link-color-hover, var(--outline-link--color-hover--computed));
+  --outline-button--link-decoration-hover--computed: var(--outline-button--link-decoration-hover, underline);
+  --outline-button--link-weight-hover--computed: var(--outline-button--link-weight-hover, var(--outline-button--weight--computed));
+  --outline-button--link-ring-hover--computed: var(--outline-button--link-ring-hover, none);
 
-/* Link Button(s) - Disabled */
---outline-button--default--link--disabled-bg-color: var(--outline-transparent);
---outline-button--default--link--disabled-text-color: var(--outline-gray-500);
---outline-button--default--link--disabled-decoration: none;
---outline-button--default--link--disabled-weight: var(--outline-button--default-weight);
---outline-button--default--link--disabled-ring: none;
+  /* Link Button(s) - Focus */
+  --outline-button--link-bg-color-focus--computed: var(--outline-button--link-bg-color-focus, var(--outline-transparent));
+  --outline-button--link-color-focus--computed: var(--outline-button--link-color-focus, var(--outline-link--color-focus--computed));
+  --outline-button--link-decoration-focus--computed: var(--outline-button--link-decoration-focus, underline);
+  --outline-button--link-weight-focus--computed: var(--outline-button--link-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--link-ring-focus--computed: var(--outline-button--link-ring-focus, none);
 
-/* Link Button(s) - Disabled:Focus */
---outline-button--default--link--disabled-bg-color-focus: var(--outline-transparent);;
---outline-button--default--link--disabled-text-color-focus: var(--outline-gray-500);
---outline-button--default--link--disabled-decoration-focus: none;
---outline-button--default--link--disabled-weight-focus: var(--outline-button--default-weight);
---outline-button--default--link--disabled-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-500);
+  /* Link Button(s) - Disabled */
+  --outline-button--link-disabled-bg-color--computed: var(--outline-button--link-disabled-bg-color, var(--outline-transparent));
+  --outline-button--link-disabled-color--computed: var(--outline-button--link-disabled-color, var(--outline-gray-500));
+  --outline-button--link-disabled-decoration--computed: var(--outline-button--link-disabled-decoration, none);
+  --outline-button--link-disabled-weight--computed: var(--outline-button--link-disabled-weight, var(--outline-button--weight--computed));
+  --outline-button--link-disabled-ring--computed: var(--outline-button--link-disabled-ring, none);
+
+  /* Link Button(s) - Disabled:Focus */
+  --outline-button--link-disabled-bg-color-focus--computed: var(--outline-button--link-disabled-bg-color-focus, var(--outline-transparent));
+  --outline-button--link-disabled-color-focus--computed: var(--outline-button--link-disabled-color-focus, var(--outline-gray-500));
+  --outline-button--link-disabled-decoration-focus--computed: var(--outline-button--link-disabled-decoration-focus, none);
+  --outline-button--link-disabled-weight-focus--computed: var(--outline-button--link-disabled-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--link-disabled-ring-focus--computed: var(--outline-button--link-disabled-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-500));
+}

--- a/packages/outline-button/src/css-variables/vars-primary.css
+++ b/packages/outline-button/src/css-variables/vars-primary.css
@@ -1,71 +1,74 @@
 /*
 Default CSS Variables for the `outline-button` primary variant.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-button` styling can be found in 
+The variables used to override the default
+`outline-button` styling can be found in
 `outline-button.ts` delcared with the `@cssprop` annotations.
 */
-/* 
+/*
 // ### CSS Variables
 
 // > The following CSS Variables are used to style the primary buttons.
 
-// - \`--outline--button--primary-padding\`: Padding for the primary buttons.
-// - \`--outline--button--primary-radius\`: Border radius for the primary buttons.
-// - \`--outline--button--primary-bg-color-default\`: Background color for the primary buttons.
-// - \`--outline--button--primary-text-color-default\`: Text color for the primary buttons.
-// - \`--outline--button--primary-weight-default\`: Font weight for the primary buttons.
-// - \`--outline--button--primary-ring-default\`: Border ring for the primary buttons.
-// - \`--outline--button--primary-bg-color-hover\`: Background color for the primary buttons when hovered.
-// - \`--outline--button--primary-text-color-hover\`: Text color for the primary buttons when hovered.
-// - \`--outline--button--primary-weight-hover\`: Font weight for the primary buttons when hovered.
-// - \`--outline--button--primary-ring-hover\`: Border ring for the primary buttons when hovered.
-// - \`--outline--button--primary-bg-color-focus\`: Background color for the primary buttons when focused.
-// - \`--outline--button--primary-text-color-focus\`: Text color for the primary buttons when focused.
-// - \`--outline--button--primary-weight-focus\`: Font weight for the primary buttons when focused.
-// - \`--outline--button--primary-ring-focus\`: Border ring for the primary buttons when focused.
-// - \`--outline--button--primary--disabled-bg-color\`: Background color for the primary buttons when disabled.
-// - \`--outline--button--primary--disabled-text-color\`: Text color for the primary buttons when disabled.
-// - \`--outline--button--primary--disabled-weight\`: Font weight for the primary buttons when disabled.
-// - \`--outline--button--primary--disabled-ring\`: Border ring for the primary buttons when disabled.
-// - \`--outline--button--primary--disabled-bg-color-focus\`: Background color for the primary buttons when disabled and focused.
-// - \`--outline--button--primary--disabled-text-color-focus\`: Text color for the primary buttons when disabled and focused.
-// - \`--outline--button--primary--disabled-weight-focus\`: Font weight for the primary buttons when disabled and focused.
-// - \`--outline--button--primary--disabled-ring-focus\`: Border ring for the primary buttons when disabled and focused.
+// - \`--outline-button--primary-padding\`: Padding for the primary buttons.
+// - \`--outline-button--primary-radius\`: Border radius for the primary buttons.
+// - \`--outline-button--primary-bg-color\`: Background color for the primary buttons.
+// - \`--outline-button--primary-text-color\`: Text color for the primary buttons.
+// - \`--outline-button--primary-weight\`: Font weight for the primary buttons.
+// - \`--outline-button--primary-ring\`: Border ring for the primary buttons.
+// - \`--outline-button--primary-bg-color-hover\`: Background color for the primary buttons when hovered.
+// - \`--outline-button--primary-text-color-hover\`: Text color for the primary buttons when hovered.
+// - \`--outline-button--primary-weight-hover\`: Font weight for the primary buttons when hovered.
+// - \`--outline-button--primary-ring-hover\`: Border ring for the primary buttons when hovered.
+// - \`--outline-button--primary-bg-color-focus\`: Background color for the primary buttons when focused.
+// - \`--outline-button--primary-text-color-focus\`: Text color for the primary buttons when focused.
+// - \`--outline-button--primary-weight-focus\`: Font weight for the primary buttons when focused.
+// - \`--outline-button--primary-ring-focus\`: Border ring for the primary buttons when focused.
+// - \`--outline-button--primary-disabled-bg-color\`: Background color for the primary buttons when disabled.
+// - \`--outline-button--primary-disabled-text-color\`: Text color for the primary buttons when disabled.
+// - \`--outline-button--primary-disabled-weight\`: Font weight for the primary buttons when disabled.
+// - \`--outline-button--primary-disabled-ring\`: Border ring for the primary buttons when disabled.
+// - \`--outline-button--primary-disabled-bg-color-focus\`: Background color for the primary buttons when disabled and focused.
+// - \`--outline-button--primary-disabled-text-color-focus\`: Text color for the primary buttons when disabled and focused.
+// - \`--outline-button--primary-disabled-weight-focus\`: Font weight for the primary buttons when disabled and focused.
+// - \`--outline-button--primary-disabled-ring-focus\`: Border ring for the primary buttons when disabled and focused.
 */
 
-/* Primary Button(s) */
---outline-button--default--primary-padding: var(--outline-button--default-padding);
---outline-button--default--primary-radius: var(--outline-button--default-radius);
+:host {
 
-/* Primary Button(s) - Default */
---outline-button--default--primary-bg-color-default: var(--outline-blue-600);
---outline-button--default--primary-text-color-default: var(--outline-white);
---outline-button--default--primary-weight-default: var(--outline-button--default-weight);
---outline-button--default--primary-ring-default: none;
+  /* Primary Button(s) */
+  --outline-button--primary-padding--computed: var(--outline-button--primary-padding, var(--outline-button--padding--computed));
+  --outline-button--primary-radius--computed: var(--outline-button--primary-radius, var(--outline-button--radius--computed));
 
-/* Primary Button(s) - Hover */
---outline-button--default--primary-bg-color-hover: var(--outline-white);
---outline-button--default--primary-text-color-hover: var(--outline-blue-600);
---outline-button--default--primary-weight-hover: var(--outline-button--default-weight);
---outline-button--default--primary-ring-hover: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600);
+  /* Primary Button(s) - Default */
+  --outline-button--primary-bg-color--computed: var(--outline-button--primary-bg-color, var(--outline-blue-600));
+  --outline-button--primary-color--computed: var(--outline-button--primary-color, var(--outline-white));
+  --outline-button--primary-weight--computed: var(--outline-button--primary-weight, var(--outline-button--weight--computed));
+  --outline-button--primary-ring--computed: var(--outline-button--primary-ring, none);
 
-/* Primary Button(s) - Focus */
---outline-button--default--primary-bg-color-focus: var(--outline-white);
---outline-button--default--primary-text-color-focus: var(--outline-blue-600);
---outline-button--default--primary-weight-focus: var(--outline-button--default-weight);
---outline-button--default--primary-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600);
+  /* Primary Button(s) - Hover */
+  --outline-button--primary-bg-color-hover--computed: var(--outline-button--primary-bg-color-hover, var(--outline-white));
+  --outline-button--primary-color-hover--computed: var(--outline-button--primary-color-hover, var(--outline-blue-600));
+  --outline-button--primary-weight-hover--computed: var(--outline-button--primary-weight-hover, var(--outline-button--weight--computed));
+  --outline-button--primary-ring-hover--computed: var(--outline-button--primary-ring-hover, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600));
 
-/* Primary Button(s) - Disabled */
---outline-button--default--primary--disabled-bg-color: var(--outline-white);
---outline-button--default--primary--disabled-text-color: var(--outline-gray-400);
---outline-button--default--primary--disabled-weight: var(--outline-button--default-weight);
---outline-button--default--primary--disabled-ring: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300);
+  /* Primary Button(s) - Focus */
+  --outline-button--primary-bg-color-focus--computed: var(--outline-button--primary-bg-color-focus, var(--outline-white));
+  --outline-button--primary-color-focus--computed: var(--outline-button--primary-color-focus, var(--outline-blue-600));
+  --outline-button--primary-weight-focus--computed: var(--outline-button--primary-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--primary-ring-focus--computed: var(--outline-button--primary-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600));
 
-/* Primary Button(s) - Disabled:Focus */
---outline-button--default--primary--disabled-bg-color-focus: var(--outline-white);
---outline-button--default--primary--disabled-text-color-focus: var(--outline-gray-400);
---outline-button--default--primary--disabled-weight-focus: var(--outline-button--default-weight);
---outline-button--default--primary--disabled-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400);
+  /* Primary Button(s) - Disabled */
+  --outline-button--primary-disabled-bg-color--computed: var(--outline-button--primary-disabled-bg-color, var(--outline-white));
+  --outline-button--primary-disabled-color--computed: var(--outline-button--primary-disabled-color, var(--outline-gray-400));
+  --outline-button--primary-disabled-weight--computed: var(--outline-button--primary-disabled-weight, var(--outline-button--weight--computed));
+  --outline-button--primary-disabled-ring--computed: var(--outline-button--primary-disabled-ring, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300));
+
+  /* Primary Button(s) - Disabled:Focus */
+  --outline-button--primary-disabled-bg-color-focus--computed: var(--outline-button--primary-disabled-bg-color-focus, var(--outline-white));
+  --outline-button--primary-disabled-color-focus--computed: var(--outline-button--primary-disabled-color-focus, var(--outline-gray-400));
+  --outline-button--primary-disabled-weight-focus--computed: var(--outline-button--primary-disabled-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--primary-disabled-ring-focus--computed: var(--outline-button--primary-disabled-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400));
+}

--- a/packages/outline-button/src/css-variables/vars-secondary.css
+++ b/packages/outline-button/src/css-variables/vars-secondary.css
@@ -1,68 +1,74 @@
 /*
 Default CSS Variables for the `outline-button` secondary variant.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-button` styling can be found in 
+The variables used to override the default
+`outline-button` styling can be found in
 `outline-button.ts` delcared with the `@cssprop` annotations.
 */
 
-/* 
---outline--button--secondary-padding
---outline--button--secondary-radius
---outline--button--secondary-bg-color-default
---outline--button--secondary-text-color-default
---outline--button--secondary-weight-default
---outline--button--secondary-ring-default
---outline--button--secondary-bg-color-hover
---outline--button--secondary-text-color-hover
---outline--button--secondary-weight-hover
---outline--button--secondary-ring-hover
---outline--button--secondary-bg-color-focus
---outline--button--secondary-text-color-focus
---outline--button--secondary-weight-focus
---outline--button--secondary-ring-focus
---outline--button--secondary--disabled-bg-color
---outline--button--secondary--disabled-text-color
---outline--button--secondary--disabled-weight
---outline--button--secondary--disabled-ring
---outline--button--secondary--disabled-bg-color-focus
---outline--button--secondary--disabled-text-color-focus
---outline--button--secondary--disabled-weight-focus
---outline--button--secondary--disabled-ring-focus
+/*
+--outline-button--secondary-padding
+--outline-button--secondary-radius
+--outline-button--secondary-bg-color
+--outline-button--secondary-text-color
+--outline-button--secondary-weight
+--outline-button--secondary-ring
+
+--outline-button--secondary-bg-color-hover
+--outline-button--secondary-text-color-hover
+--outline-button--secondary-weight-hover
+--outline-button--secondary-ring-hover
+
+--outline-button--secondary-bg-color-focus
+--outline-button--secondary-text-color-focus
+--outline-button--secondary-weight-focus
+--outline-button--secondary-ring-focus
+
+--outline-button--secondary-disabled-bg-color
+--outline-button--secondary-disabled-text-color
+--outline-button--secondary-disabled-weight
+--outline-button--secondary-disabled-ring
+--outline-button--secondary-disabled-bg-color-focus
+--outline-button--secondary-disabled-text-color-focus
+--outline-button--secondary-disabled-weight-focus
+--outline-button--secondary-disabled-ring-focus
 */
 
-/* Secondary Button(s) */
---outline-button--default--secondary-padding: var(--outline-button--default-padding);
---outline-button--default--secondary-radius: var(--outline-button--default-radius);
+:host {
 
-/* Secondary Button(s) - Default */
---outline-button--default--secondary-bg-color-default: var(--outline-white);
---outline-button--default--secondary-text-color-default: var(--outline-blue-600);
---outline-button--default--secondary-weight-default: var(--outline-button--default-weight);
---outline-button--default--secondary-ring-default: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600);
+  /* Secondary Button(s) */
+  --outline-button--secondary-padding--computed: var(--outline-button--secondary-padding, var(--outline-button--padding--computed));
+  --outline-button--secondary-radius--computed: var(--outline-button--secondary-radius, var(--outline-button--radius--computed));
 
-/* Secondary Button(s) - Hover */
---outline-button--default--secondary-bg-color-hover: var(--outline-blue-600);
---outline-button--default--secondary-text-color-hover: var(--outline-white);
---outline-button--default--secondary-weight-hover: var(--outline-button--default-weight);
---outline-button--default--secondary-ring-hover: none;
+  /* Secondary Button(s) - Default */
+  --outline-button--secondary-bg-color--computed: var(--outline-button--secondary-bg-color, var(--outline-white));
+  --outline-button--secondary-color--computed: var(--outline-button--secondary-color, var(--outline-blue-600));
+  --outline-button--secondary-weight--computed: var(--outline-button--secondary-weight, var(--outline-button--weight--computed));
+  --outline-button--secondary-ring--computed: var(--outline-button--secondary-ring, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-blue-600));
 
-/* Secondary Button(s) - Focus */
---outline-button--default--secondary-bg-color-focus: var(--outline-blue-600);
---outline-button--default--secondary-text-color-focus: var(--outline-white);
---outline-button--default--secondary-weight-focus: var(--outline-button--default-weight);
---outline-button--default--secondary-ring-focus: none;
+  /* Secondary Button(s) - Hover */
+  --outline-button--secondary-bg-color-hover--computed: var(--outline-button--secondary-bg-color-hover, var(--outline-blue-600));
+  --outline-button--secondary-color-hover--computed: var(--outline-button--secondary-color-hover, var(--outline-white));
+  --outline-button--secondary-weight-hover--computed: var(--outline-button--secondary-weight-hover, var(--outline-button--weight--computed));
+  --outline-button--secondary-ring-hover--computed: var(--outline-button--secondary-ring-hover, none);
 
-/* Secondary Button(s) - Disabled */
---outline-button--default--secondary--disabled-bg-color: var(--outline-white);
---outline-button--default--secondary--disabled-text-color: var(--outline-gray-400);
---outline-button--default--secondary--disabled-weight: var(--outline-button--default-weight);
---outline-button--default--secondary--disabled-ring: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300);
+  /* Secondary Button(s) - Focus */
+  --outline-button--secondary-bg-color-focus--computed: var(--outline-button--secondary-bg-color-focus, var(--outline-blue-600));
+  --outline-button--secondary-color-focus--computed: var(--outline-button--secondary-color-focus, var(--outline-white));
+  --outline-button--secondary-weight-focus--computed: var(--outline-button--secondary-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--secondary-ring-focus--computed: var(--outline-button--secondary-ring-focus, none);
 
-/* Secondary Button(s) - Disabled:Focus */
---outline-button--default--secondary--disabled-bg-color-focus: var(--outline-white);
---outline-button--default--secondary--disabled-text-color-focus: var(--outline-gray-400);
---outline-button--default--secondary--disabled-weight-focus: var(--outline-button--default-weight);
---outline-button--default--secondary--disabled-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400);
+  /* Secondary Button(s) - Disabled */
+  --outline-button--secondary-disabled-bg-color--computed: var(--outline-button--secondary-disabled-bg-color, var(--outline-white));
+  --outline-button--secondary-disabled-color--computed: var(--outline-button--secondary-disabled-color, var(--outline-gray-400));
+  --outline-button--secondary-disabled-weight--computed: var(--outline-button--secondary-disabled-weight, var(--outline-button--weight--computed));
+  --outline-button--secondary-disabled-ring--computed: var(--outline-button--secondary-disabled-ring, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300));
+
+  /* Secondary Button(s) - Disabled:Focus */
+  --outline-button--secondary-disabled-bg-color-focus--computed: var(--outline-button--secondary-disabled-bg-color-focus, var(--outline-white));
+  --outline-button--secondary-disabled-color-focus--computed: var(--outline-button--secondary-disabled-color-focus, var(--outline-gray-400));
+  --outline-button--secondary-disabled-weight-focus--computed: var(--outline-button--secondary-disabled-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--secondary-disabled-ring-focus--computed: var(--outline-button--secondary-disabled-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400));
+}

--- a/packages/outline-button/src/css-variables/vars-tertiary.css
+++ b/packages/outline-button/src/css-variables/vars-tertiary.css
@@ -1,69 +1,73 @@
 /*
 Default CSS Variables for the `outline-button` tertiary variant.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-button` styling can be found in 
+The variables used to override the default
+`outline-button` styling can be found in
 `outline-button.ts` delcared with the `@cssprop` annotations.
 */
 
-/* 
---outline--button--tertiary-padding
---outline--button--tertiary-radius
---outline--button--tertiary-padding
---outline--button--tertiary-radius
---outline--button--tertiary-bg-color-default
---outline--button--tertiary-text-color-default
---outline--button--tertiary-weight-default
---outline--button--tertiary-ring-default
---outline--button--tertiary-bg-color-hover
---outline--button--tertiary-text-color-hover
---outline--button--tertiary-weight-hover
---outline--button--tertiary-ring-hover
---outline--button--tertiary-bg-color-focus
---outline--button--tertiary-text-color-focus
---outline--button--tertiary-weight-focus
---outline--button--tertiary-ring-focus
---outline--button--tertiary--disabled-bg-color
---outline--button--tertiary--disabled-text-color
---outline--button--tertiary--disabled-weight
---outline--button--tertiary--disabled-ring
---outline--button--tertiary--disabled-bg-color-focus
---outline--button--tertiary--disabled-text-color-focus
---outline--button--tertiary--disabled-weight-focus
---outline--button--tertiary--disabled-ring-focus
+/*
+--outline-button--tertiary-padding
+--outline-button--tertiary-radius
+--outline-button--tertiary-padding
+--outline-button--tertiary-radius
+--outline-button--tertiary-bg-color
+--outline-button--tertiary-text-color
+--outline-button--tertiary-weight
+--outline-button--tertiary-ring
+--outline-button--tertiary-bg-color-hover
+--outline-button--tertiary-text-color-hover
+--outline-button--tertiary-weight-hover
+--outline-button--tertiary-ring-hover
+--outline-button--tertiary-bg-color-focus
+--outline-button--tertiary-text-color-focus
+--outline-button--tertiary-weight-focus
+--outline-button--tertiary-ring-focus
+--outline-button--tertiary-disabled-bg-color
+--outline-button--tertiary-disabled-text-color
+--outline-button--tertiary-disabled-weight
+--outline-button--tertiary-disabled-ring
+--outline-button--tertiary-disabled-bg-color-focus
+--outline-button--tertiary-disabled-text-color-focus
+--outline-button--tertiary-disabled-weight-focus
+--outline-button--tertiary-disabled-ring-focus
 */
 
---outline-button--default--tertiary-padding: var(--outline-button--default-padding);
---outline-button--default--tertiary-radius: var(--outline-button--default-radius); 
+:host {
 
-/* Tertiary Button(s) - Default */
---outline-button--default--tertiary-bg-color-default: var(--outline-soft-black);
---outline-button--default--tertiary-text-color-default: var(--outline-white);
---outline-button--default--tertiary-weight-default: var(--outline-button--default-weight);
---outline-button--default--tertiary-ring-default: none;
+  /* Tertiary Button(s) */
+  --outline-button--tertiary-padding--computed: var(--outline-button--tertiary-padding, var(--outline-button--padding--computed));
+  --outline-button--tertiary-radius--computed: var(--outline-button--tertiary-radius, var(--outline-button--radius--computed));
 
-/* Tertiary Button(s) - Hover */
---outline-button--default--tertiary-bg-color-hover: var(--outline-white);
---outline-button--default--tertiary-text-color-hover: var(--outline-soft-black);
---outline-button--default--tertiary-weight-hover: var(--outline-button--default-weight);
---outline-button--default--tertiary-ring-hover: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-soft-black);
+  /* Tertiary Button(s) - Default */
+  --outline-button--tertiary-bg-color--computed: var(--outline-button--tertiary-bg-color, var(--outline-soft-black));
+  --outline-button--tertiary-color--computed: var(--outline-button--tertiary-color, var(--outline-white));
+  --outline-button--tertiary-weight--computed: var(--outline-button--tertiary-weight, var(--outline-button--weight--computed));
+  --outline-button--tertiary-ring--computed: var(--outline-button--tertiary-ring, none);
 
-/* Tertiary Button(s) - Focus */
---outline-button--default--tertiary-bg-color-focus: var(--outline-white);
---outline-button--default--tertiary-text-color-focus: var(--outline-soft-black);
---outline-button--default--tertiary-weight-focus: var(--outline-button--default-weight);
---outline-button--default--tertiary-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-soft-black);
+  /* Tertiary Button(s) - Hover */
+  --outline-button--tertiary-bg-color-hover--computed: var(--outline-button--tertiary-bg-color-hover, var(--outline-white));
+  --outline-button--tertiary-color-hover--computed: var(--outline-button--tertiary-color-hover, var(--outline-soft-black));
+  --outline-button--tertiary-weight-hover--computed: var(--outline-button--tertiary-weight-hover, var(--outline-button--weight--computed));
+  --outline-button--tertiary-ring-hover--computed: var(--outline-button--tertiary-ring-hover, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-soft-black));
 
-/* Tertiary Button(s) - Disabled */
---outline-button--default--tertiary--disabled-bg-color: var(--outline-white);
---outline-button--default--tertiary--disabled-text-color: var(--outline-gray-400);
---outline-button--default--tertiary--disabled-weight: var(--outline-button--default-weight);
---outline-button--default--tertiary--disabled-ring: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300);
+  /* Tertiary Button(s) - Focus */
+  --outline-button--tertiary-bg-color-focus--computed: var(--outline-button--tertiary-bg-color-focus, var(--white));
+  --outline-button--tertiary-color-focus--computed: var(--outline-button--tertiary-color-focus, var(--outline-soft-black));
+  --outline-button--tertiary-weight-focus--computed: var(--outline-button--tertiary-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--tertiary-ring-focus--computed: var(--outline-button--tertiary-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-soft-black));
 
-/* Tertiary Button(s) - Disabled:Focus */
---outline-button--default--tertiary--disabled-bg-color-focus: var(--outline-white);
---outline-button--default--tertiary--disabled-text-color-focus: var(--outline-gray-400);
---outline-button--default--tertiary--disabled-weight-focus: var(--outline-button--default-weight);
---outline-button--default--tertiary--disabled-ring-focus: var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400);
+  /* Tertiary Button(s) - Disabled */
+  --outline-button--tertiary-disabled-bg-color--computed: var(--outline-button--tertiary-disabled-bg-color, var(--outline-white));
+  --outline-button--tertiary-disabled-color--computed: var(--outline-button--tertiary-disabled-color, var(--outline-gray-400));
+  --outline-button--tertiary-disabled-weight--computed: var(--outline-button--tertiary-disabled-weight, var(--outline-button--weight--computed));
+  --outline-button--tertiary-disabled-ring--computed: var(--outline-button--tertiary-disabled-ring, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-300));
+
+  /* Tertiary Button(s) - Disabled:Focus */
+  --outline-button--tertiary-disabled-bg-color-focus--computed: var(--outline-button--tertiary-disabled-bg-color-focus, var(--outline-white));
+  --outline-button--tertiary-disabled-color-focus--computed: var(--outline-button--tertiary-disabled-color-focus, var(--outline-gray-400));
+  --outline-button--tertiary-disabled-weight-focus--computed: var(--outline-button--tertiary-disabled-weight-focus, var(--outline-button--weight--computed));
+  --outline-button--tertiary-disabled-ring-focus--computed: var(--outline-button--tertiary-disabled-ring-focus, var(--outline-ring-inset) 0 0 0 var(--outline-ring-offset-width) var(--outline-gray-400));
+}

--- a/packages/outline-button/src/outline-button.css
+++ b/packages/outline-button/src/outline-button.css
@@ -1,3 +1,9 @@
+@import './css-variables/vars-default.css';
+@import './css-variables/vars-link.css';
+@import './css-variables/vars-primary.css';
+@import './css-variables/vars-secondary.css';
+@import './css-variables/vars-tertiary.css';
+
 :host {
   /*
    * Configuration values for `outline-button`.
@@ -25,13 +31,10 @@
 
   line-height: 1.5;
 
-  border-radius: var(
-    --outline-btn-radius,
-    var(--outline-button--default-radius)
-  );
-  font-family: var(--outline-btn-family, var(--outline-button--default-family));
-  font-weight: var(--outline-btn-weight, var(--outline-button--default-weight));
-  padding: var(--outline-btn-padding, var(--outline-button--default-padding));
+  border-radius: var(--outline-button--radius--computed);
+  font-family: var(--outline-button--family--computed);
+  font-weight: var(--outline-button--weight--computed);
+  padding: var(--outline-button--padding--computed);
 }
 
 .btn[aria-disabled='true'] {
@@ -41,441 +44,159 @@
 }
 
 .btn.primary {
-  padding: var(
-    --outline--button--primary-padding,
-    var(--outline-btn-padding, var(--outline-button--default--primary-padding))
-  );
-  border-radius: var(
-    --outline--button--primary-radius,
-    var(--outline-btn-radius, var(--outline-button--default-radius))
-  );
+  padding: var(--outline-button--primary-padding--computed);
+  border-radius: var(--outline-button--primary-radius--computed);
   /* Can change per button state */
-  background-color: var(
-    --outline--button--primary-bg-color-default,
-    var(--outline-button--default--primary-bg-color-default)
-  );
-  color: var(
-    --outline--button--primary-text-color-default,
-    var(--outline-button--default--primary-text-color-default)
-  );
-  font-weight: var(
-    --outline--button--primary-weight-default,
-    var(--outline-button--default--primary-weight-default)
-  );
-  box-shadow: var(
-    --outline--button--primary-ring-default,
-    var(--outline-button--default--primary-ring-default)
-  );
+  background-color: var(--outline-button--primary-bg-color--computed);
+  color: var(--outline-button--primary-color--computed);
+  font-weight: var(--outline-button--primary-weight--computed);
+  box-shadow: var(--outline-button--primary-ring--computed);
 
   &:hover {
-    background-color: var(
-      --outline--button--primary-bg-color-hover,
-      var(--outline-button--default--primary-bg-color-hover)
-    );
-    color: var(
-      --outline--button--primary-text-color-hover,
-      var(--outline-button--default--primary-text-color-hover)
-    );
-    font-weight: var(
-      --outline--button--primary-weight-hover,
-      var(--outline-button--default--primary-weight-hover)
-    );
-    box-shadow: var(
-      --outline--button--primary-ring-hover,
-      var(--outline-button--default--primary-ring-hover)
-    );
+    background-color: var(--outline-button--primary-bg-color-hover--computed);
+    color: var(--outline-button--primary-color-hover--computed);
+    font-weight: var(--outline-button--primary-weight-hover--computed);
+    box-shadow: var(--outline-button--primary-ring-hover--computed)
   }
 
   &:focus {
-    background-color: var(
-      --outline--button--primary-bg-color-focus,
-      var(--outline-button--default--primary-bg-color-focus)
-    );
-    color: var(
-      --outline--button--primary-text-color-focus,
-      var(--outline-button--default--primary-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--primary-weight-focus,
-      var(--outline-button--default--primary-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--primary-ring-focus,
-      var(--outline-button--default--primary-ring-focus)
-    );
+    background-color: var(--outline-button--primary-bg-color-focus--computed);
+    color: var(--outline-button--primary-color-focus--computed);
+    font-weight: var(--outline-button--primary-weight-focus--computed);
+    box-shadow: var(--outline-button--primary-ring-focus--computed);
   }
 }
 
 .btn.primary[aria-disabled='true'] {
-  background-color: var(
-    --outline--button--primary--disabled-bg-color,
-    var(--outline-button--default--primary--disabled-bg-color)
-  );
-  color: var(
-    --outline--button--primary--disabled-text-color,
-    var(--outline-button--default--primary--disabled-text-color)
-  );
-  font-weight: var(
-    --outline--button--primary--disabled-weight,
-    var(--outline-button--default--primary--disabled-weight)
-  );
-  box-shadow: var(
-    --outline--button--primary--disabled-ring,
-    var(--outline-button--default--primary--disabled-ring)
-  );
+  background-color: var(--outline-button--primary-disabled-bg-color--computed);
+  color: var(--outline-button--primary-disabled-color--computed);
+  font-weight: var(--outline-button--primary-disabled-weight--computed);
+  box-shadow: var(--outline-button--primary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(
-      --outline--button--primary--disabled-bg-color-focus,
-      var(--outline-button--default--primary--disabled-bg-color-focus)
-    );
-    color: var(
-      --outline--button--primary--disabled-text-color-focus,
-      var(--outline-button--default--primary--disabled-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--primary--disabled-weight-focus,
-      var(--outline-button--default--primary--disabled-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--primary--disabled-ring-focus,
-      var(--outline-button--default--primary--disabled-ring-focus)
-    );
+    background-color: var(--outline-button--primary-disabled-bg-color-focus--computed);
+    color: var(--outline-button--primary-disabled-color-focus--computed);
+    font-weight: var(--outline-button--primary-disabled-weight-focus--computed);
+    box-shadow: var(--outline-button--primary-disabled-ring-focus--computed);
   }
 }
 
 .btn.secondary {
-  padding: var(
-    --outline--button--secondary-padding,
-    var(
-      --outline-btn-padding,
-      var(--outline-button--default--secondary-padding)
-    )
-  );
-  border-radius: var(
-    --outline--button--secondary-radius,
-    var(--outline-btn-radius, var(--outline-button--default-radius))
-  );
+  padding: var(--outline-button--secondary-padding--computed);
+  border-radius: var(--outline-button--secondary-radius--computed);
 
-  background-color: var(
-    --outline--button--secondary-bg-color-default,
-    var(--outline-button--default--secondary-bg-color-default)
-  );
-  color: var(
-    --outline--button--secondary-text-color-default,
-    var(--outline-button--default--secondary-text-color-default)
-  );
-  font-weight: var(
-    --outline--button--secondary-weight-default,
-    var(--outline-button--default--secondary-weight-default)
-  );
-  box-shadow: var(
-    --outline--button--secondary-ring-default,
-    var(--outline-button--default--secondary-ring-default)
-  );
+  background-color: var(--outline-button--secondary-bg-color--computed);
+  color: var(--outline-button--secondary-color--computed);
+  font-weight: var(--outline-button--secondary-weight--computed);
+  box-shadow: var(--outline-button--secondary-ring--computed);
 
   &:hover {
-    background-color: var(
-      --outline--button--secondary-bg-color-hover,
-      var(--outline-button--default--secondary-bg-color-hover)
-    );
-    color: var(
-      --outline--button--secondary-text-color-hover,
-      var(--outline-button--default--secondary-text-color-hover)
-    );
-    font-weight: var(
-      --outline--button--secondary-weight-hover,
-      var(--outline-button--default--secondary-weight-hover)
-    );
-    box-shadow: var(
-      --outline--button--secondary-ring-hover,
-      var(--outline-button--default--secondary-ring-hover)
-    );
+    background-color: var(--outline-button--secondary-bg-color-hover--computed);
+    color: var(--outline-button--secondary-color-hover--computed);
+    font-weight: var(--outline-button--secondary-weight-hover--computed);
+    box-shadow: var(--outline-button--secondary-ring-hover--computed);
   }
 
   &:focus {
-    background-color: var(
-      --outline--button--secondary-bg-color-focus,
-      var(--outline-button--default--secondary-bg-color-focus)
-    );
-    color: var(
-      --outline--button--secondary-text-color-focus,
-      var(--outline-button--default--secondary-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--secondary-weight-focus,
-      var(--outline-button--default--secondary-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--secondary-ring-focus,
-      var(--outline-button--default--secondary-ring-focus)
-    );
+    background-color: var(--outline-button--secondary-bg-color-focus--computed);
+    color: var(--outline-button--secondary-color-focus--computed);
+    font-weight: var(--outline-button--secondary-weight-focus--computed);
+    box-shadow: var(--outline-button--secondary-ring-focus--computed);
   }
 }
 
 .btn.secondary[aria-disabled='true'] {
-  background-color: var(
-    --outline--button--secondary--disabled-bg-color,
-    var(--outline-button--default--secondary--disabled-bg-color)
-  );
-  color: var(
-    --outline--button--secondary--disabled-text-color,
-    var(--outline-button--default--secondary--disabled-text-color)
-  );
-  font-weight: var(
-    --outline--button--secondary--disabled-weight,
-    var(--outline-button--default--secondary--disabled-weight)
-  );
-  box-shadow: var(
-    --outline--button--secondary--disabled-ring,
-    var(--outline-button--default--secondary--disabled-ring)
-  );
+  background-color: var(--outline-button--secondary-disabled-bg-color--computed);
+  color: var(--outline-button--secondary-disabled-color--computed);
+  font-weight: var(--outline-button--secondary-disabled-weight--computed);
+  box-shadow: var(--outline-button--secondary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(
-      --outline--button--secondary--disabled-bg-color-focus,
-      var(--outline-button--default--secondary--disabled-bg-color-focus)
-    );
-    color: var(
-      --outline--button--secondary--disabled-text-color-focus,
-      var(--outline-button--default--secondary--disabled-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--secondary--disabled-weight-focus,
-      var(--outline-button--default--secondary--disabled-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--secondary--disabled-ring-focus,
-      var(--outline-button--default--secondary--disabled-ring-focus)
-    );
+    background-color: var(--outline-button--secondary-disabled-bg-color-focus--computed);
+    color: var(--outline-button--secondary-disabled-color-focus--computed);
+    font-weight: var(--outline-button--secondary-disabled-weight-focus--computed);
+    box-shadow: var(--outline-button--secondary-disabled-ring-focus--computed);
   }
 }
 
 .btn.tertiary {
-  padding: var(
-    --outline--button--tertiary-padding,
-    var(--outline-btn-padding, var(--outline-button--default--tertiary-padding))
-  );
-  border-radius: var(
-    --outline--button--tertiary-radius,
-    var(--outline-btn-radius, var(--outline-button--default-radius))
-  );
+  padding: var(--outline-button--tertiary-padding--computed);
+  border-radius: var(--outline-button--tertiary-radius--computed);
 
-  background-color: var(
-    --outline--button--tertiary-bg-color-default,
-    var(--outline-button--default--tertiary-bg-color-default)
-  );
-  color: var(
-    --outline--button--tertiary-text-color-default,
-    var(--outline-button--default--tertiary-text-color-default)
-  );
-  font-weight: var(
-    --outline--button--tertiary-weight-default,
-    var(--outline-button--default--tertiary-weight-default)
-  );
-  box-shadow: var(
-    --outline--button--tertiary-ring-default,
-    var(--outline-button--default--tertiary-ring-default)
-  );
+  background-color: var(--outline-button--tertiary-bg-color--computed);
+  color: var(--outline-button--tertiary-color--computed);
+  font-weight: var(--outline-button--tertiary-weight-default--computed);
+  box-shadow: var(--outline-button--tertiary-ring-default--computed);
 
   &:hover {
-    background-color: var(
-      --outline--button--tertiary-bg-color-hover,
-      var(--outline-button--default--tertiary-bg-color-hover)
-    );
-    color: var(
-      --outline--button--tertiary-text-color-hover,
-      var(--outline-button--default--tertiary-text-color-hover)
-    );
-    font-weight: var(
-      --outline--button--tertiary-weight-hover,
-      var(--outline-button--default--tertiary-weight-hover)
-    );
-    box-shadow: var(
-      --outline--button--tertiary-ring-hover,
-      var(--outline-button--default--tertiary-ring-hover)
-    );
+    background-color: var(--outline-button--tertiary-bg-color-hover--computed);
+    color: var(--outline-button--tertiary-color-hover--computed);
+    font-weight: var(--outline-button--tertiary-weight-hover--computed);
+    box-shadow: var(--outline-button--tertiary-ring-hover--computed);
   }
 
   &:focus {
-    background-color: var(
-      --outline--button--tertiary-bg-color-focus,
-      var(--outline-button--default--tertiary-bg-color-focus)
-    );
-    color: var(
-      --outline--button--tertiary-text-color-focus,
-      var(--outline-button--default--tertiary-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--tertiary-weight-focus,
-      var(--outline-button--default--tertiary-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--tertiary-ring-focus,
-      var(--outline-button--default--tertiary-ring-focus)
-    );
+    background-color: var(--outline-button--tertiary-bg-color-focus--computed);
+    color: var(--outline-button--tertiary-color-focus--computed);
+    font-weight: var(--outline-button--tertiary-weight-focus--computed);
+    box-shadow: var(--outline-button--tertiary-ring-focus--computed);
   }
 }
 
 .btn.tertiary[aria-disabled='true'] {
-  background-color: var(
-    --outline--button--tertiary--disabled-bg-color,
-    var(--outline-button--default--tertiary--disabled-bg-color)
-  );
-  color: var(
-    --outline--button--tertiary--disabled-text-color,
-    var(--outline-button--default--tertiary--disabled-text-color)
-  );
-  font-weight: var(
-    --outline--button--tertiary--disabled-weight,
-    var(--outline-button--default--tertiary--disabled-weight)
-  );
-  box-shadow: var(
-    --outline--button--tertiary--disabled-ring,
-    var(--outline-button--default--tertiary--disabled-ring)
-  );
+  background-color: var(--outline-button--tertiary-disabled-bg-color--computed);
+  color: var(--outline-button--tertiary-disabled-color--computed);
+  font-weight: var(--outline-button--tertiary-disabled-weight--computed);
+  box-shadow: var(--outline-button--tertiary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(
-      --outline--button--tertiary--disabled-bg-color-focus,
-      var(--outline-button--default--tertiary--disabled-bg-color-focus)
-    );
-    color: var(
-      --outline--button--tertiary--disabled-text-color-focus,
-      var(--outline-button--default--tertiary--disabled-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--tertiary--disabled-weight-focus,
-      var(--outline-button--default--tertiary--disabled-weight-focus)
-    );
-    box-shadow: var(
-      --outline--button--tertiary--disabled-ring-focus,
-      var(--outline-button--default--tertiary--disabled-ring-focus)
-    );
+    background-color: var(--outline-button--tertiary-disabled-bg-color-focus--computed);
+    color: var(--outline-button--tertiary-disabled-color-focus--computed);
+    font-weight: var(--outline-button--tertiary-disabled-weight-focus--computed);
+    box-shadow: var(--outline-button--tertiary-disabled-ring-focus--computed);
   }
 }
 
 .btn.link {
-  padding: var(
-    --outline--button--link-padding,
-    var(--outline-btn-padding, var(--outline-button--default--link-padding))
-  );
-  border-radius: var(
-    --outline--button--link-radius,
-    var(--outline-btn-radius, var(--outline-button--default-radius))
-  );
+  padding: var(--outline-button--link-padding--computed);
+  border-radius: var(--outline-button--link-radius--computed);
 
-  background-color: var(
-    --outline--button--link-bg-color-default,
-    var(--outline-button--default--link-bg-color-default)
-  );
-  color: var(
-    --outline--button--link-text-color-default,
-    var(--outline-button--default--link-text-color-default)
-  );
-  font-weight: var(
-    --outline--button--link-weight-default,
-    var(--outline-button--default--link-weight-default)
-  );
-  text-decoration: var(
-    --outline--button--link-decoration-default,
-    var(--outline-button--default--link-decoration-default)
-  );
-  box-shadow: var(
-    --outline--button--link-ring-default,
-    var(--outline-button--default--link-ring-default)
-  );
+  background-color: var(--outline-button--link-bg-color--computed);
+  color: var(--outline-button--link-color--computed);
+  font-weight: var(--outline-button--link-weight--computed);
+  text-decoration: var(--outline-button--link-decoration--computed);
+  box-shadow: var(--outline-button--link-ring--computed);
 
   &:hover {
-    background-color: var(
-      --outline--button--link-bg-color-hover,
-      var(--outline-button--default--link-bg-color-hover)
-    );
-    color: var(
-      --outline--button--link-text-color-hover,
-      var(--outline-button--default--link-text-color-hover)
-    );
-    font-weight: var(
-      --outline--button--link-weight-hover,
-      var(--outline-button--default--link-weight-hover)
-    );
-    text-decoration: var(
-      --outline--button--link-decoration-hover,
-      var(--outline-button--default--link-decoration-hover)
-    );
-    box-shadow: var(
-      --outline--button--link-ring-hover,
-      var(--outline-button--default--link-ring-hover)
-    );
+    background-color: var(--outline-button--link-bg-color-hover--computed);
+    color: var(--outline-button--link-color-hover--computed);
+    font-weight: var(--outline-button--link-weight-hover--computed);
+    text-decoration: var(--outline-button--link-decoration-hover--computed);
+    box-shadow: var(--outline-button--link-ring-hover--computed);
   }
 
   &:focus {
-    background-color: var(
-      --outline--button--link-bg-color-focus,
-      var(--outline-button--default--link-bg-color-focus)
-    );
-    color: var(
-      --outline--button--link-text-color-focus,
-      var(--outline-button--default--link-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--link-weight-focus,
-      var(--outline-button--default--link-weight-focus)
-    );
-    text-decoration: var(
-      --outline--button--link-decoration-focus,
-      var(--outline-button--default--link-decoration-focus)
-    );
-    box-shadow: var(
-      --outline--button--link-ring-focus,
-      var(--outline-button--default--link-ring-focus)
-    );
+    background-color: var(--outline-button--link-bg-color-focus--computed);
+    color: var(--outline-button--link-color-focus--computed);
+    font-weight: var(--outline-button--link-weight-focus--computed);
+    text-decoration: var(--outline-button--link-decoration-focus--computed);
+    box-shadow: var(--outline-button--link-ring-focus--computed);
   }
 }
 
 .btn.link[aria-disabled='true'] {
-  background-color: var(
-    --outline--button--link--disabled-bg-color,
-    var(--outline-button--default--link--disabled-bg-color)
-  );
-  color: var(
-    --outline--button--link--disabled-text-color,
-    var(--outline-button--default--link--disabled-text-color)
-  );
-  font-weight: var(
-    --outline--button--link--disabled-weight,
-    var(--outline-button--default--link--disabled-weight)
-  );
-  text-decoration: var(
-    --outline--button--link--disabled-decoration,
-    var(--outline-button--default--link--disabled-decoration)
-  );
-  box-shadow: var(
-    --outline--button--link--disabled-ring,
-    var(--outline-button--default--link--disabled-ring)
-  );
+  background-color: var(--outline-button--link-disabled-bg-color--computed);
+  color: var(--outline-button--link-disabled-color--computed);
+  font-weight: var(--outline-button--link-disabled-weight--computed);
+  text-decoration: var(--outline-button--link-disabled-decoration--computed);
+  box-shadow: var(--outline-button--link-disabled-ring--computed);
 
   &:focus {
-    background-color: var(
-      --outline--button--link--disabled-bg-color-focus,
-      var(--outline-button--default--link--disabled-bg-color-focus)
-    );
-    color: var(
-      --outline--button--link--disabled-text-color-focus,
-      var(--outline-button--default--link--disabled-text-color-focus)
-    );
-    font-weight: var(
-      --outline--button--link--disabled-weight-focus,
-      var(--outline-button--default--link--disabled-weight-focus)
-    );
-    text-decoration: var(
-      --outline--button--link--disabled-decoration-focus,
-      var(--outline-button--default--link--disabled-decoration-focus)
-    );
-    box-shadow: var(
-      --outline--button--link--disabled-ring-focus,
-      var(--outline-button--default--link--disabled-ring-focus)
-    );
+    background-color: var(--outline-button--link-disabled-bg-color-focus--computed);
+    color: var(--outline-button--link-disabled-color-focus--computed);
+    font-weight: var(--outline-button--link-disabled-weight-focus--computed);
+    text-decoration: var(--outline-button--link-disabled-decoration-focus--computed);
+    box-shadow: var(--outline-button--link-disabled-ring-focus--computed);
   }
 }
 

--- a/packages/outline-button/src/outline-button.css
+++ b/packages/outline-button/src/outline-button.css
@@ -56,7 +56,7 @@
     background-color: var(--outline-button--primary-bg-color-hover--computed);
     color: var(--outline-button--primary-color-hover--computed);
     font-weight: var(--outline-button--primary-weight-hover--computed);
-    box-shadow: var(--outline-button--primary-ring-hover--computed)
+    box-shadow: var(--outline-button--primary-ring-hover--computed);
   }
 
   &:focus {
@@ -74,7 +74,9 @@
   box-shadow: var(--outline-button--primary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(--outline-button--primary-disabled-bg-color-focus--computed);
+    background-color: var(
+      --outline-button--primary-disabled-bg-color-focus--computed
+    );
     color: var(--outline-button--primary-disabled-color-focus--computed);
     font-weight: var(--outline-button--primary-disabled-weight-focus--computed);
     box-shadow: var(--outline-button--primary-disabled-ring-focus--computed);
@@ -106,15 +108,21 @@
 }
 
 .btn.secondary[aria-disabled='true'] {
-  background-color: var(--outline-button--secondary-disabled-bg-color--computed);
+  background-color: var(
+    --outline-button--secondary-disabled-bg-color--computed
+  );
   color: var(--outline-button--secondary-disabled-color--computed);
   font-weight: var(--outline-button--secondary-disabled-weight--computed);
   box-shadow: var(--outline-button--secondary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(--outline-button--secondary-disabled-bg-color-focus--computed);
+    background-color: var(
+      --outline-button--secondary-disabled-bg-color-focus--computed
+    );
     color: var(--outline-button--secondary-disabled-color-focus--computed);
-    font-weight: var(--outline-button--secondary-disabled-weight-focus--computed);
+    font-weight: var(
+      --outline-button--secondary-disabled-weight-focus--computed
+    );
     box-shadow: var(--outline-button--secondary-disabled-ring-focus--computed);
   }
 }
@@ -150,9 +158,13 @@
   box-shadow: var(--outline-button--tertiary-disabled-ring--computed);
 
   &:focus {
-    background-color: var(--outline-button--tertiary-disabled-bg-color-focus--computed);
+    background-color: var(
+      --outline-button--tertiary-disabled-bg-color-focus--computed
+    );
     color: var(--outline-button--tertiary-disabled-color-focus--computed);
-    font-weight: var(--outline-button--tertiary-disabled-weight-focus--computed);
+    font-weight: var(
+      --outline-button--tertiary-disabled-weight-focus--computed
+    );
     box-shadow: var(--outline-button--tertiary-disabled-ring-focus--computed);
   }
 }
@@ -192,10 +204,14 @@
   box-shadow: var(--outline-button--link-disabled-ring--computed);
 
   &:focus {
-    background-color: var(--outline-button--link-disabled-bg-color-focus--computed);
+    background-color: var(
+      --outline-button--link-disabled-bg-color-focus--computed
+    );
     color: var(--outline-button--link-disabled-color-focus--computed);
     font-weight: var(--outline-button--link-disabled-weight-focus--computed);
-    text-decoration: var(--outline-button--link-disabled-decoration-focus--computed);
+    text-decoration: var(
+      --outline-button--link-disabled-decoration-focus--computed
+    );
     box-shadow: var(--outline-button--link-disabled-ring-focus--computed);
   }
 }

--- a/packages/outline-button/src/outline-button.ts
+++ b/packages/outline-button/src/outline-button.ts
@@ -6,11 +6,6 @@ import { OutlineElement, SlotController } from '@phase2/outline-core';
 import { LinkTargetType } from '@phase2/outline-link';
 
 import { linkVars } from '@phase2/outline-link';
-import defaultVars from './css-variables/vars-default.css.lit';
-import primaryButtonVars from './css-variables/vars-primary.css.lit';
-import secondaryButtonVars from './css-variables/vars-secondary.css.lit';
-import tertiaryButtonVars from './css-variables/vars-tertiary.css.lit';
-import linkButtonVars from './css-variables/vars-link.css.lit';
 import componentStyles from './outline-button.css.lit';
 
 export type ButtonVariant = 'link' | 'primary' | 'secondary' | 'tertiary';
@@ -35,11 +30,6 @@ export type ButtonSize = 'small' | 'medium' | 'large';
 export class OutlineButton extends OutlineElement {
   static styles: CSSResultGroup = [
     linkVars,
-    defaultVars,
-    primaryButtonVars,
-    secondaryButtonVars,
-    tertiaryButtonVars,
-    linkButtonVars,
     componentStyles,
   ];
 

--- a/packages/outline-button/src/outline-button.ts
+++ b/packages/outline-button/src/outline-button.ts
@@ -28,10 +28,7 @@ export type ButtonSize = 'small' | 'medium' | 'large';
  */
 @customElement('outline-button')
 export class OutlineButton extends OutlineElement {
-  static styles: CSSResultGroup = [
-    linkVars,
-    componentStyles,
-  ];
+  static styles: CSSResultGroup = [linkVars, componentStyles];
 
   slots = new SlotController(
     this, // This, the host element.

--- a/packages/outline-button/src/outline-split-button/outline-split-button.css
+++ b/packages/outline-button/src/outline-split-button/outline-split-button.css
@@ -8,95 +8,37 @@
   padding: 0 !important;
 }
 
-/* .button__trigger:hover
-  + .icon__trigger
-  .icon__button[button-variant='primary'] {
-  background-color: var(
-    --outline--button--primary-bg-color-hover,
-    var(--outline-button--default--primary-bg-color-hover)
-  );
-  color: var(
-    --outline--button--primary-text-color-hover,
-    var(--outline-button--default--primary-text-color-hover)
-  );
-  font-weight: var(
-    --outline--button--primary-weight-hover,
-    var(--outline-button--default--primary-weight-hover)
-  );
-  box-shadow: var(
-    --outline--button--primary-ring-hover,
-    var(--outline-button--default--primary-ring-hover)
-  );
-}
-.button__trigger:hover
-  + .icon__trigger
-  outline-button[button-variant='secondary'] {
-}
-.button__trigger:hover
-  + .icon__trigger
-  outline-button[button-variant='tertiary'] {
-}
-.button__trigger:hover + .icon__trigger outline-button[button-variant='link'] {
-} */
-
 /* Reassign button padding to the actual link */
 ::slotted(.button__trigger) {
   display: flex;
-  padding: var(--outline-btn-padding, var(--outline-button--default-padding));
+  padding: var(--outline-button--padding--computed);
 }
 
 /* Primary variant */
 [trigger-variant='primary'] ::slotted(.button__trigger) {
-  padding: var(
-    --outline--button--primary-padding,
-    var(--outline-btn-padding, var(--outline-button--default--primary-padding))
-  );
+  padding: var(--outline-button--primary-padding--computed);
 }
 
 [trigger-variant='primary']:hover ::slotted(.icon__trigger) .btn.primary {
-  background-color: var(
-    --outline--button--primary-bg-color-hover,
-    var(--outline-button--default--primary-bg-color-hover)
-  );
-  color: var(
-    --outline--button--primary-text-color-hover,
-    var(--outline-button--default--primary-text-color-hover)
-  );
-  font-weight: var(
-    --outline--button--primary-weight-hover,
-    var(--outline-button--default--primary-weight-hover)
-  );
-  box-shadow: var(
-    --outline--button--primary-ring-hover,
-    var(--outline-button--default--primary-ring-hover)
-  );
+  background-color: var(--outline-button--primary-bg-color-hover--computed);
+  color: var(--outline-button--primary-text-color-hover--computed);
+  font-weight: var(--outline-button--primary-weight-hover--computed);
+  box-shadow: var(--outline-button--primary-ring-hover--computed);
 }
 
 /* Secondary variant */
 [trigger-variant='secondary'] ::slotted(.button__trigger) {
-  padding: var(
-    --outline--button--secondary-padding,
-    var(
-      --outline-btn-padding,
-      var(--outline-button--default--secondary-padding)
-    )
-  );
+  padding: var(--outline-button--secondary-padding--computed);
 }
 
 /* Tertiary variant */
 [trigger-variant='tertiary'] ::slotted(.button__trigger) {
-  padding: var(
-    --outline--button--tertiary-padding,
-    var(--outline-btn-padding, var(--outline-button--default--tertiary-padding))
-  );
+  padding: var(--outline-button--tertiary-padding--computed);
 }
 
 /* Link variant */
 [trigger-variant='link'] ::slotted(.button__trigger) {
-  padding: var(
-    --outline--button--link-padding,
-    var(--outline-btn-padding, var(--outline-button--default--link-padding))
-  );
+  padding: var(--outline-button--link-padding--computed);
 }
 
 ::slotted(.icon__trigger) {

--- a/packages/outline-dropdown/src/outline-dropdown.css
+++ b/packages/outline-dropdown/src/outline-dropdown.css
@@ -36,22 +36,10 @@
 
 .dropdown--open {
   .btn.primary {
-    background-color: var(
-      --outline--button--primary-bg-color-hover,
-      var(--outline-button--default--primary-bg-color-hover)
-    );
-    color: var(
-      --outline--button--primary-text-color-hover,
-      var(--outline-button--default--primary-text-color-hover)
-    );
-    font-weight: var(
-      --outline--button--primary-weight-hover,
-      var(--outline-button--default--primary-weight-hover)
-    );
-    box-shadow: var(
-      --outline--button--primary-ring-hover,
-      var(--outline-button--default--primary-ring-hover)
-    );
+    background-color: var(--outline-button--primary-bg-color-hover--computed);
+    color: var(--outline-button--primary-text-color-hover--computed);
+    font-weight: var(--outline-button--primary-weight-hover--computed);
+    box-shadow: var(--outline-button--primary-ring-hover--computed);
   }
 }
 
@@ -69,54 +57,33 @@
   pointer-events: all;
 }
 
-/* 
+/*
   Applies a margin to the span containing the button text
-  assuming there is a button-url, meaning there should be an 
-  icon for opening a dropdown. 
+  assuming there is a button-url, meaning there should be an
+  icon for opening a dropdown.
 */
 outline-split-button {
 }
 
 outline-button {
   .btn {
-    padding: var(--outline-btn-padding, var(--outline-button--default-padding));
+    padding: var(--outline-button--padding--computed);
   }
 
   .btn.primary {
-    padding: var(
-      --outline--button--primary-padding,
-      var(
-        --outline-btn-padding,
-        var(--outline-button--default--primary-padding)
-      )
-    );
+    padding: var(--outline-button--primary-padding--computed);
   }
 
   .btn.secondary {
-    padding: var(
-      --outline--button--secondary-padding,
-      var(
-        --outline-btn-padding,
-        var(--outline-button--default--secondary-padding)
-      )
-    );
+    padding: var(--outline-button--secondary-padding--computed);
   }
 
   .btn.tertiary {
-    padding: var(
-      --outline--button--tertiary-padding,
-      var(
-        --outline-btn-padding,
-        var(--outline-button--default--tertiary-padding)
-      )
-    );
+    padding: var(--outline-button--tertiary-padding--computed);
   }
 
   .btn.link {
-    padding: var(
-      --outline--button--link-padding,
-      var(--outline-btn-padding, var(--outline-button--default--link-padding))
-    );
+    padding: var(--outline-button--link-padding--computed);
   }
 
   .btn.primary:hover {

--- a/packages/outline-link/src/css-variables/vars-link.css
+++ b/packages/outline-link/src/css-variables/vars-link.css
@@ -1,19 +1,21 @@
 /*
 Default CSS Variables for `outline-link`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-link` styling can be found in 
+The variables used to override the default
+`outline-link` styling can be found in
 `outline-link.ts` delcared with the `@cssprop` annotations.
 */
 
---outline--link-default-transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
---outline--link-default-transition-duration: 150ms;
---outline--link-default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
---outline--link-default-color-default: var(--outline-blue-600);
---outline--link-default-color-default-decoration: none;
---outline--link-default-color-hover: var(--outline--gray-600);
---outline--link-default-color-hover-decoration: underline;
---outline--link-default-color-focus: var(--outline--gray-600);
---outline--link-default-color-focus-decoration: underline;
+:host {
+  --outline-link--color--computed: var(--outline-link--color, var(--outline-blue-600));
+  --outline-link--text-decoration--computed: var(--outline-link--text-decoration, none);
+  --outline-link--color-hover--computed: var(--outline-link--color-hover, var(--outline-gray-600));
+  --outline-link--text-decoration-hover--computed: var(--outline-link--text-decoration-hover, underline);
+  --outline-link--color-focus--computed: var(--outline-link--color-focus, var(--outline-gray-600));
+  --outline-link--text-decoration-focus--computed: var(--outline-link--text-decoration-focus, underline);
+  --outline-link--transition-property--computed: var(--outline-link--transition-property, color, background-color, border-color, text-decoration-color, fill, stroke);
+  --outline-link--transition-duration--computed:  var(--outline-link--transition-duration, 150ms);
+  --outline-link--transition-timing-function--computed: var(--outline-link--transition-timing-function, cubic-bezier(0.4, 0, 0.2, 1));
+}

--- a/packages/outline-link/src/outline-link.css
+++ b/packages/outline-link/src/outline-link.css
@@ -1,52 +1,24 @@
-:host,
+@import './css-variables/vars-link.css';
+
 a,
 ::slotted(a) {
   font-family: var(--ff-body);
-  text-decoration: var(
-    --outline-link-color-default-decoration,
-    var(--outline--link-default-color-default-decoration)
-  );
-  color: var(
-    --outline-link-color-default,
-    var(--outline--link-default-color-default)
-  );
-  transition-property: var(
-    --outline-link-transition-property,
-    var(--outline--link-default-transition-property)
-  );
-  transition-timing-function: var(
-    --outline-link-transition-timing-function,
-    var(--outline--link-default-transition-timing-function)
-  );
-  transition-duration: var(
-    --outline-link-transition-duration,
-    var(--outline--link-default-transition-duration)
-  );
+  text-decoration: var(--outline-link--text-decoration--computed);
+  color: var(--outline-link--color--computed);
+  transition-property: var(--outline-link--transition-property--computed);
+  transition-timing-function: var(--outline-link--transition-timing-function--computed);
+  transition-duration: var(--outline-link--transition-duration--computed);
 }
 
-:host(:hover),
 a:hover,
 ::slotted(a:hover) {
-  text-decoration: var(
-    --outline-link-color-hover-decoration,
-    var(--outline--link-default-color-hover-decoration)
-  );
-  color: var(
-    --outline-link-color-hover,
-    var(--outline--link-default-color-hover)
-  );
+  text-decoration: var(--outline-link--text-decoration-hover--computed);
+  color: var(--outline-link--color-hover--computed);
 }
 
-:host(:focus),
 a:focus,
 ::slotted(a:focus) {
-  text-decoration: var(
-    --outline-link-color-focus-decoration,
-    var(--outline--link-default-color-focus-decoration)
-  );
-  color: var(
-    --outline-link-color-focus,
-    var(--outline--link-default-color-focus)
-  );
+  text-decoration: var(--outline-link--text-decoration-focus--computed);
+  color: var(--outline-link--color-focus--computed);
   outline: none;
 }

--- a/packages/outline-link/src/outline-link.css
+++ b/packages/outline-link/src/outline-link.css
@@ -6,7 +6,9 @@ a,
   text-decoration: var(--outline-link--text-decoration--computed);
   color: var(--outline-link--color--computed);
   transition-property: var(--outline-link--transition-property--computed);
-  transition-timing-function: var(--outline-link--transition-timing-function--computed);
+  transition-timing-function: var(
+    --outline-link--transition-timing-function--computed
+  );
   transition-duration: var(--outline-link--transition-duration--computed);
 }
 

--- a/packages/outline-link/src/outline-link.ts
+++ b/packages/outline-link/src/outline-link.ts
@@ -6,7 +6,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { OutlineElement } from '@phase2/outline-core';
 
 import type { LinkTargetType, LinkRelType } from './config';
-import componentVars from './css-variables/vars-link.css.lit';
 import componentStyles from './outline-link.css.lit';
 
 /**
@@ -27,7 +26,7 @@ import componentStyles from './outline-link.css.lit';
  */
 @customElement('outline-link')
 export class OutlineLink extends OutlineElement {
-  static styles: CSSResultGroup = [componentVars, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
   /**
    * Link url
    */

--- a/packages/outline-list/README.md
+++ b/packages/outline-list/README.md
@@ -24,13 +24,13 @@ The OutlineList component
 
 ## CSS Custom Properties
 
-| Property                              | Description                                      |
-|---------------------------------------|--------------------------------------------------|
-| `--outline-list-default-spacing`      | The default spacing between items.               |
-| `--outline-list-default-spacing-lg`   | The default spacing between items for large screens. |
-| `--outline-list-default-spacing-md`   | The default spacing between items for medium screens. |
-| `--outline-list-default-spacing-sm`   | The default spacing between items for small screens. |
-| `--outline-list-default-spacing-xl`   | The default spacing between items for extra large screens. |
-| `--outline-list-default-spacing-xs`   | The default spacing between items for extra small screens. |
-| `--outline-list-default-spacing-xxl`  | The default spacing between items for extra extra large screens. |
-| `--outline-list-default-spacing-xxxl` | The default spacing between items for extra extra extra large screens. |
+| Property                       | Description                                      |
+|--------------------------------|--------------------------------------------------|
+| `--outline-list--spacing`      | The default spacing between items.               |
+| `--outline-list--spacing-lg`   | The default spacing between items for large screens. |
+| `--outline-list--spacing-md`   | The default spacing between items for medium screens. |
+| `--outline-list--spacing-sm`   | The default spacing between items for small screens. |
+| `--outline-list--spacing-xl`   | The default spacing between items for extra large screens. |
+| `--outline-list--spacing-xs`   | The default spacing between items for extra small screens. |
+| `--outline-list--spacing-xxl`  | The default spacing between items for extra extra large screens. |
+| `--outline-list--spacing-xxxl` | The default spacing between items for extra extra extra large screens. |

--- a/packages/outline-list/src/css-variables/vars-list.css
+++ b/packages/outline-list/src/css-variables/vars-list.css
@@ -1,19 +1,17 @@
 /*
 Default CSS Variables for `outline-list`.
-You can override these using `outline.theme.css`, 
+You can override these using `outline.theme.css`,
 or any css file in your consumer application with
 a later loading order than `outline.theme.css`.
-The variables used to override the default 
-`outline-list` styling can be found in 
-`outline-list.ts` delcared with the `@cssprop` annotations.
 */
 
---outline--list-default-spacing: var(--spacing-4);
---outline--list-default-spacing-xs: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-sm: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-md: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-lg: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-xl: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-xxl: var(--outline--list-default-spacing, var(--spacing-4));
---outline--list-default-spacing-xxxl: var(--outline--list-default-spacing, var(--spacing-4));
-
+:host {
+  --outline-list--spacing--computed: var(--outline-list--spacing, var(--spacing-4));
+  --outline-list--spacing-xs--computed: var(--outline-list--spacing-xs, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-sm--computed: var(--outline-list--spacing-sm, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-md--computed: var(--outline--list--spacing-md, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-lg--computed: var(--outline--list--spacing-lg, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-xl--computed: var(--outline--list--spacing-xl, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-xxl--computed: var(--outline--list--spacing-xxl, var(--outline-list--spacing, var(--spacing-4)));
+  --outline-list--spacing-xxxl--computed: var(--outline--list--spacing-xxxl, var(--outline-list--spacing, var(--spacing-4)));
+}

--- a/packages/outline-list/src/outline-list.css
+++ b/packages/outline-list/src/outline-list.css
@@ -1,3 +1,5 @@
+@import './css-variables/vars-list.css';
+
 .list {
   border: unset;
   margin: 0;
@@ -21,18 +23,12 @@ ol.grid > ::slotted(li) {
 }
 
 .list.row ::slotted(*:not(:last-of-type)) {
-  margin-right: var(
-    --outline--list-spacing,
-    var(--outline--list-default-spacing)
-  );
+  margin-right: var(--outline-list--spacing--computed);
 }
 
 .list.column ::slotted(*:not(:last-of-type)),
 .list.col-center ::slotted(*:not(:last-of-type)) {
-  margin-bottom: var(
-    --outline--list-spacing,
-    var(--outline--list-default-spacing)
-  );
+  margin-bottom: var(--outline-list--spacing--computed);
 }
 
 .columns--2,

--- a/packages/outline-list/src/outline-list.ts
+++ b/packages/outline-list/src/outline-list.ts
@@ -4,7 +4,6 @@ import { classMap } from 'lit/directives/class-map.js';
 
 import { OutlineElement } from '@phase2/outline-core';
 
-import componentVars from './css-variables/vars-list.css.lit';
 import componentStyles from './outline-list.css.lit';
 
 export const listTypes = ['ol', 'ul', 'div'] as const;
@@ -22,14 +21,14 @@ export type ClassInfo = { [name: string]: string | boolean | number };
  * @element outline-list
  * @extends OutlineElement
  *
- * @cssprop --outline-list-default-spacing - The default spacing between items.
- * @cssprop --outline-list-default-spacing-xs - The default spacing between items for extra small screens.
- * @cssprop --outline-list-default-spacing-sm - The default spacing between items for small screens.
- * @cssprop --outline-list-default-spacing-md - The default spacing between items for medium screens.
- * @cssprop --outline-list-default-spacing-lg - The default spacing between items for large screens.
- * @cssprop --outline-list-default-spacing-xl - The default spacing between items for extra large screens.
- * @cssprop --outline-list-default-spacing-xxl - The default spacing between items for extra extra large screens.
- * @cssprop --outline-list-default-spacing-xxxl - The default spacing between items for extra extra extra large screens.
+ * @cssprop --outline-list--spacing - The default spacing between items.
+ * @cssprop --outline-list--spacing-xs - The default spacing between items for extra small screens.
+ * @cssprop --outline-list--spacing-sm - The default spacing between items for small screens.
+ * @cssprop --outline-list--spacing-md - The default spacing between items for medium screens.
+ * @cssprop --outline-list--spacing-lg - The default spacing between items for large screens.
+ * @cssprop --outline-list--spacing-xl - The default spacing between items for extra large screens.
+ * @cssprop --outline-list--spacing-xxl - The default spacing between items for extra extra large screens.
+ * @cssprop --outline-list--spacing-xxxl - The default spacing between items for extra extra extra large screens.
  *
  * @slot default slot.
  * @slot heading: for content above the default slot.
@@ -37,7 +36,7 @@ export type ClassInfo = { [name: string]: string | boolean | number };
  */
 @customElement('outline-list')
 export class OutlineList extends OutlineElement {
-  static styles: CSSResultGroup = [componentVars, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
 
   /**
    * Determines which type of list is rendered.

--- a/packages/outline-storybook/config/storybook.main.css
+++ b/packages/outline-storybook/config/storybook.main.css
@@ -455,7 +455,7 @@ video{
   border-color: currentColor;
 
 }
-.shadow-xl, .shadow, .shadow-md{
+.shadow-md, .shadow-xl, .shadow{
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
@@ -949,6 +949,13 @@ video{
   text-decoration: none;
 
 }
+.shadow-md{
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: 0 0 #0000, 0 0 #0000, var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+
+}
 .shadow-xl{
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
@@ -959,13 +966,6 @@ video{
 .shadow{
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  box-shadow: 0 0 #0000, 0 0 #0000, var(--tw-shadow);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-
-}
-.shadow-md{
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
   box-shadow: 0 0 #0000, 0 0 #0000, var(--tw-shadow);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 

--- a/scripts/styles.js
+++ b/scripts/styles.js
@@ -109,7 +109,6 @@ const createVariableLiterals = (result, path) => {
 import { css } from 'lit';
 export default css\`
 /* Apply CSS Variables to the host element. */
-:host {
 ${result.css}\`;`,
     () => true
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,56 +2897,10 @@
     "@types/sinon-chai" "^3.2.3"
     chai-a11y-axe "^1.3.2"
 
-"@phase2/outline-alert@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-alert/-/outline-alert-0.0.2.tgz#b77cf3fba8766b52e12aa80c33b511869c2f74c5"
-  integrity sha512-PanNjcdq8kRzU7wFG0O1ZgKknA4hLnN+hddqgHld30anLMEN6AQ/v+3PWn2zusj8Nv04AmxA1C6pTMqxu1RZMw==
-  dependencies:
-    "@phase2/outline-core" "^0.0.2"
-    lit "^2.3.1"
-    tslib "^2.1.0"
-
-"@phase2/outline-code-block@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-code-block/-/outline-code-block-0.0.2.tgz#8c6edd076b73ed90fb9274ef3ef29966152e185a"
-  integrity sha512-wPuudnULxYhime0lthDqETZyYDCkmoyfBsHJjnE3X7ypW1lThrRDCj5Ta6FjKu7MiUdULKkdJdAUiYrm/0SzPw==
-  dependencies:
-    "@phase2/outline-core" "^0.0.2"
-    lit "^2.3.1"
-    tslib "^2.1.0"
-
 "@phase2/outline-config@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@phase2/outline-config/-/outline-config-0.0.1.tgz#b3ccc3ae49166032753fe1165022e3752a6e50ac"
   integrity sha512-HoZhL4aqCjdm2HE3YvJgGLboJRPNJLXkRt0UqP0sofxJneAjAJsIdsCKnwecW6ANsEhTAzn0NUbW/g2S+cCuLw==
-
-"@phase2/outline-config@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-config/-/outline-config-0.0.2.tgz#79304f44b55321a18f13114808fd4e6daaf3bc32"
-  integrity sha512-OIMZrNVtHAPThma7lVaeJb96y/bunFIXFHDrhWiSWbhpgKk3gUp7ePIvfrzUeieW+B+kLBiRyzLEsEM69u685Q==
-
-"@phase2/outline-core@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-core/-/outline-core-0.0.2.tgz#05d833ece387fdd42962a9e1c89bb95ef0d885c8"
-  integrity sha512-1p300ISueihcSdsVsbeDL1MKxV6SnYxt0XOoQbqeswdSL6vYBgeyXXyX9/pkHXcncyVRd+yNdXEF2/7LcWdA3g==
-  dependencies:
-    "@phase2/outline-config" "^0.0.2"
-    lit "^2.0.2"
-
-"@phase2/outline-static-assets@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-static-assets/-/outline-static-assets-0.0.2.tgz#5e04cb14c61faf3203ddb760d76c7095880817fa"
-  integrity sha512-J7Hh3TozV81BxMP7UuVn3Ooj7tZwZ1/88xV9JWHM7vv8mG6zMpf2rk/1oOL+oHL3R4sNat1c3eCim157xtDrQQ==
-
-"@phase2/outline-storybook@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@phase2/outline-storybook/-/outline-storybook-0.0.10.tgz#73fea29989179c8b4fd8db1f9cf6eef996119850"
-  integrity sha512-zQu3zWLDw8YD5nFa31rOUV1RZU+1tsmFhnazTw2/v3n9kd4splO8NNSV5ugmlr24O3P7aj+xvLijTte6k63WuA==
-  dependencies:
-    "@phase2/outline-alert" "^0.0.2"
-    "@phase2/outline-code-block" "^0.0.2"
-    "@phase2/outline-core" "^0.0.2"
-    "@phase2/outline-static-assets" "^0.0.2"
 
 "@phase2/outline-templates@^0.0.12":
   version "0.0.12"


### PR DESCRIPTION
## Description

Refactors all usage of CSS Variables to comply with https://github.com/phase2/phase2-adr/pull/17

Components affected:
- outline-admin-links
- outline-alert
- outline-breadcrumbs
- outline-button
- outline-dropdown
- outline-link
- outline-list

In addition to supporting the naming convention listed in the ADR, especially around the use of `--computed`, also modified the `styles.js` script to avoid adding `:host{}` around files in the `css-variables` folder in favor of putting the `:host` directly in the vars.css files themselves. This change:
- allows the vars.css files to be directly imported into the component main css file, avoiding the need for using `componentVars` in the typescript file
- supports future functionality of styling in the light DOM.
- removes "magic" from the build process.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

This is a breaking change for any project currently using the new mono repo and overriding CSS variables since some variables have changed names.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
