### PR TITLE
Adjusting outline-docs package so projects can use them

### DIFF
--- a/packages/outline-docs/README.md
+++ b/packages/outline-docs/README.md
@@ -1,70 +1,33 @@
-# outline-dropdown
+# outline-docs
 
-## Properties
+This provides a base set of documentation about Outline for projects to include in their storybook instances.
 
-| Property            | Attribute         | Type                       | Default                          | Description                                      |
-|---------------------|-------------------|----------------------------|----------------------------------|--------------------------------------------------|
-| `containingElement` |                   | `HTMLElement \| undefined` |                                  | The dropdown will close when the user interacts outside of this element (e.g. clicking). |
-| `hasDropdown`       |                   | `boolean`                  |                                  |                                                  |
-| `hasFooter`         |                   | `boolean`                  |                                  |                                                  |
-| `hasHeader`         |                   | `boolean`                  |                                  |                                                  |
-| `isDisabled`        | `is-disabled`     | `boolean`                  | false                            | Disables the dropdown so the panel will not open. |
-| `isLink`            |                   | `boolean`                  | false                            | Determines if the dropdown trigger is a link or not. |
-| `isOpen`            | `is-open`         | `boolean`                  | false                            | Indicates whether or not the dropdown is open.<br />You can use this in lieu of the show/hide methods. |
-| `panel`             |                   | `HTMLElement`              |                                  |                                                  |
-| `slots`             |                   | `SlotController`           | "new SlotController(this, true)" |                                                  |
-| `trigger`           |                   | `HTMLElement`              |                                  |                                                  |
-| `triggerLabel`      | `trigger-label`   | `string`                   |                                  | ARIA label attribute to pass down to the resulting button or a<br />element. This is required for accessibility if we use a button<br />with an icon only. |
-| `triggerTarget`     | `trigger-target`  | `LinkTargetType`           |                                  | The target to use for a link, used in conjunction with the url attribute. |
-| `triggerText`       | `trigger-text`    | `string`                   |                                  | Visible text for the button/link of the trigger element. |
-| `triggerUrl`        | `trigger-url`     | `string`                   |                                  | The url to use for a link. This will render an anchor element.<br />Do not set this prop if you want to render a button element. |
-| `triggerVariant`    | `trigger-variant` | `ButtonVariant`            | "link"                           | The button style variant to use.                 |
+The following shows a very minimal sample of how to get the included stories into your Storybook instance.
 
-## Methods
+Use it as a guide to modify your `src/.storybook/main.js` file or wherever your project is defining config for storybook.
 
-| Method                    | Type                                             | Description                                  |
-|---------------------------|--------------------------------------------------|----------------------------------------------|
-| `buttonTemplate`          | `(): TemplateResult<ResultType> \| null`         | Template partial for the "button" rendering. |
-| `dropdownTemplate`        | `(): TemplateResult<ResultType> \| null`         | Template partial for the dropdown rendering. |
-| `focusOnTrigger`          | `(): void`                                       |                                              |
-| `footerTemplate`          | `(): TemplateResult<ResultType> \| null`         | Template partial for the footer rendering.   |
-| `handleButtonTrigger`     | `(event: KeyboardEvent): void`                   |                                              |
-| `handleDocumentMouseDown` | `(event: MouseEvent): void`                      |                                              |
-| `handleEnterKeyDown`      | `(event: KeyboardEvent, isIcon?: boolean): void` |                                              |
-| `handleEscKeyDown`        | `(event: KeyboardEvent): void`                   |                                              |
-| `handleFocusChange`       | `(): void`                                       |                                              |
-| `handleHoverStyles`       | `(): void`                                       |                                              |
-| `handleIconClick`         | `(event: MouseEvent): void`                      |                                              |
-| `handleIconTrigger`       | `(event: KeyboardEvent): void`                   |                                              |
-| `handleOpenChange`        | `(): Promise<void>`                              |                                              |
-| `handlePanelKeystrokes`   | `(event: KeyboardEvent): void`                   |                                              |
-| `headerTemplate`          | `(): TemplateResult<ResultType> \| null`         | Template partial for the header rendering.   |
-| `hide`                    | `(): Promise<void>`                              | Hides the dropdown panel.                    |
-| `iconTemplate`            | `(): TemplateResult<ResultType> \| null`         | Template partial for the icon rendering.     |
-| `iconWrapperTemplate`     | `(): TemplateResult<ResultType> \| null`         | Template partial for the icon rendering.     |
-| `show`                    | `(): Promise<void>`                              | Shows the dropdown panel.                    |
+```js
+import {outlineStories} from '@phase2/outline-docs';
 
-## Events
-
-| Event                | Description                                      |
-|----------------------|--------------------------------------------------|
-| `outline-after-hide` | Emitted after the dropdown closes and all animations are complete. |
-| `outline-after-show` | Emitted after the dropdown opens and all animations are complete. |
-| `outline-hide`       | Emitted when the dropdown closes.                |
-| `outline-show`       | Emitted when the dropdown opens.                 |
-
-## Slots
-
-| Name       | Description                                      |
-|------------|--------------------------------------------------|
-| `dropdown` | Content to be rendered in the dropdown.          |
-| `footer`   | Content to be rendered in the footer of the dropdown. |
-| `header`   | Content to be rendered in the header of the dropdown. |
-
-## CSS Shadow Parts
-
-| Part      | Description                                      |
-|-----------|--------------------------------------------------|
-| `base`    | The component's base wrapper.                    |
-| `panel`   | The panel that gets shown when the dropdown is open. |
-| `trigger` | The container that wraps the trigger.            |
+module exports {
+  features: {
+    storyStoreV7: true,
+    postcss: false,
+    buildStoriesJson: true,
+    modernInlineRender: true,
+  },
+  framework: {
+    name: '@storybook/web-components-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: true,
+    defaultName: 'Full Documentation', // set to change the name of generated docs entries
+  },
+  stories: [
+    ...outlineStories,
+    '../components/**/*.stories.@(js|ts|mdx)',
+    './stories/!(guides|tokens|demonstration|examples)**/*.stories.@(js|jsx|ts|tsx|mdx)',
+  ],
+}
+```

--- a/packages/outline-docs/index.ts
+++ b/packages/outline-docs/index.ts
@@ -1,1 +1,12 @@
-export default {};
+export const outlineStories = [
+  // Intentionally ordering welcome page first.
+  `${__dirname}/src/guides/welcome.mdx`,
+  // Component development guides.
+  `${__dirname}/src/guides/development/component-development/**/*.mdx`,
+  // Component usage guides.
+  `${__dirname}/src/guides/consumers/**/*.mdx`,
+  // QA/UAT usage guides.
+  `${__dirname}/src/guides/qa-uat/**/*.mdx`,
+  // Tooling usage guides.
+  `${__dirname}/src/guides/tooling/**/*.mdx`,
+];

--- a/packages/outline-docs/package.json
+++ b/packages/outline-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-docs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Outline Documentation",
   "keywords": [
     "outline",
@@ -23,7 +23,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js && cp -r src dist",
     "package": "yarn publish"
   },
   "dependencies": {

--- a/packages/outline-storybook/config/main.js
+++ b/packages/outline-storybook/config/main.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const outlineConfig = require('../../outline.config');
+import {outlineStories} from '@phase2/outline-docs';
 
 const excludedStories = outlineConfig.excludedStories;
 function getExcluded() {
@@ -23,6 +24,7 @@ module.exports = {
   },
   staticDirs: ['../assets'],
   stories: [
+    ...outlineStories,
     // // Explicitly order the main documentation.
     //'./stories/guides/welcome.stories.mdx',
     // // Intentionally order the Code Style Guide pages.

--- a/packages/outline-storybook/package.json
+++ b/packages/outline-storybook/package.json
@@ -15,6 +15,7 @@
     "@phase2/outline-core": "^0.1.10",
     "@phase2/outline-alert": "^0.1.6",
     "@phase2/outline-code-block": "^0.1.1",
+    "@phase2/outline-docs": "^0.0.9",
     "@phase2/outline-static-assets": "^0.0.3"
   },
   "devDependencies": {

--- a/packages/outline-templates/default/package.json
+++ b/packages/outline-templates/default/package.json
@@ -88,6 +88,7 @@
     "@phase2/outline-config": "^0.0.1",
     "@phase2/outline-container": "^0.0.1",
     "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-docs": "^0.0.9",
     "@phase2/outline-dropdown": "^0.1.0",
     "@phase2/outline-examples": "^0.0.3",
     "@phase2/outline-form": "^0.0.1",

--- a/packages/outline-templates/package.json
+++ b/packages/outline-templates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phase2/outline-templates",
   "description": "The Outline Starter Templates",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "license": "MIT",
   "scripts": {
     "package": "yarn publish"


### PR DESCRIPTION
## Description

Modify the build to actually include the documentation files, correct README, and change the template for spinning up new projects to automatically include them in the storybook instance. This will result in the Documentation folder with welcome and guides one sees on https://outline.phase2tech.com/ to be present in the project's Storybook instance as well.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manually on local instance
- [ ] Visual Testing
- [ ] Automated Testing
- [ ] Accessibility Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
