### PR TITLE
fix: remove lightDomStyles import from core

### DIFF
--- a/packages/outline-core/index.ts
+++ b/packages/outline-core/index.ts
@@ -6,7 +6,6 @@ export { LinkedBlockController } from './src/controllers/linked-block-controller
 export { MobileController } from './src/controllers/mobile-controller';
 export { ScreenSizeController } from './src/controllers/screen-size-controller';
 export { SlotsController } from './src/controllers/slots-controller';
-export { LightDomStyles } from './src/controllers/light-dom-styles';
 export { animateTo } from './src/internal/animate';
 export { emit, waitForEvent } from './src/internal/event';
 export { watch } from './src/internal/watch';

--- a/packages/outline-form/src/outline-form.ts
+++ b/packages/outline-form/src/outline-form.ts
@@ -1,8 +1,8 @@
 import { TemplateResult, html, CSSResultGroup } from 'lit';
-import { OutlineElement, LightDomStyles } from '@phase2/outline-core';
+import { OutlineElement } from '@phase2/outline-core';
 import { customElement } from 'lit/decorators.js';
 import componentStyles from './outline-form.css.lit';
-import globalStyles from './outline-form.global.scoped.css.lit';
+//import globalStyles from './outline-form.global.scoped.css.lit';
 
 /**
  * The Outline Form component
@@ -12,9 +12,9 @@ import globalStyles from './outline-form.global.scoped.css.lit';
  */
 @customElement('outline-form')
 export class OutlineForm extends OutlineElement {
-  static styles: CSSResultGroup = [OutlineElement.styles, componentStyles];
-
-  lightDomStyles = new LightDomStyles(this, globalStyles);
+  static styles = componentStyles;
+// Removing due to LightDomStyles dependency
+  //lightDomStyles = new LightDomStyles(this, globalStyles);
 
   render(): TemplateResult {
     return html`<slot></slot>`;

--- a/packages/outline-form/src/outline-form.ts
+++ b/packages/outline-form/src/outline-form.ts
@@ -13,7 +13,7 @@ import componentStyles from './outline-form.css.lit';
 @customElement('outline-form')
 export class OutlineForm extends OutlineElement {
   static styles = componentStyles;
-// Removing due to LightDomStyles dependency
+  // Removing due to LightDomStyles dependency
   //lightDomStyles = new LightDomStyles(this, globalStyles);
 
   render(): TemplateResult {


### PR DESCRIPTION
## Description

Removing the import for lightDomStyles controller as it currently prevents any components from being created by developers. 

Issues blocking projects documented here: https://phase2.slack.com/archives/C01RRSPB62F/p1687539660099819
