### PR TITLE
Fix for `LightDomStyles` controller. 

### DIFF
--- a/packages/outline-accordion/CHANGELOG.md
+++ b/packages/outline-accordion/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @phase2/outline-accordion
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-icon@0.1.3
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-accordion/package.json
+++ b/packages/outline-accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-accordion",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web accordion component",
   "keywords": [
     "outline components",
@@ -27,8 +27,8 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
-    "@phase2/outline-icon": "^0.1.2",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-icon": "^0.1.3",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-admin-links/CHANGELOG.md
+++ b/packages/outline-admin-links/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-admin-links
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-admin-links/package.json
+++ b/packages/outline-admin-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-admin-links",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the outline-admin-links component",
   "keywords": [
     "outline components",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-alert/CHANGELOG.md
+++ b/packages/outline-alert/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-alert
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/outline-alert/package.json
+++ b/packages/outline-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-alert",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The Outline Components for the web alert component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-breadcrumbs/CHANGELOG.md
+++ b/packages/outline-breadcrumbs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-breadcrumbs
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-breadcrumbs/package.json
+++ b/packages/outline-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-breadcrumbs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web breadcrumb component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-button-group/CHANGELOG.md
+++ b/packages/outline-button-group/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-button-group
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/outline-button-group/package.json
+++ b/packages/outline-button-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-button-group",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The Outline Components for the web button group component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-button/CHANGELOG.md
+++ b/packages/outline-button/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @phase2/outline-button
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-link@0.1.5
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-button/package.json
+++ b/packages/outline-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-button",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web button component",
   "keywords": [
     "outline components",
@@ -27,8 +27,8 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
-    "@phase2/outline-link": "^0.1.4",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-link": "^0.1.5",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-card/CHANGELOG.md
+++ b/packages/outline-card/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-card
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/outline-card/package.json
+++ b/packages/outline-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-card",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The Outline Components for the web card component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-cli/CHANGELOG.md
+++ b/packages/outline-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @phase2/outline-cli
 
+## 0.0.43
+
+### Patch Changes
+
+- @phase2/outline-storybook@0.0.39
+
 ## 0.0.42
 
 ### Patch Changes

--- a/packages/outline-cli/package.json
+++ b/packages/outline-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phase2/outline-cli",
   "description": "Outline command-line interface for creating new Outline projects and Outline commands",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "author": "Phase2 Technology",
   "bin": {
     "outline": "./bin/run"
@@ -11,7 +11,7 @@
     "@oclif/core": "^1",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.0.1",
-    "@phase2/outline-storybook": "^0.0.38",
+    "@phase2/outline-storybook": "^0.0.39",
     "@phase2/outline-templates": "^0.0.44",
     "@types/inquirer": "^9.0.3",
     "chalk": "^4.1.2",

--- a/packages/outline-code-block/CHANGELOG.md
+++ b/packages/outline-code-block/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-code-block
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-code-block/package.json
+++ b/packages/outline-code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-code-block",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the web code block component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-container/CHANGELOG.md
+++ b/packages/outline-container/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-container
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-container/package.json
+++ b/packages/outline-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-container",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the container web component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-core-link/CHANGELOG.md
+++ b/packages/outline-core-link/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-core-link
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/outline-core-link/package.json
+++ b/packages/outline-core-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-core-link",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The Outline Components for the web link component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-core/CHANGELOG.md
+++ b/packages/outline-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @phase2/outline-core
 
+## 0.2.0
+
+### Minor Changes
+
+- Updated lightDomStyles functionality for components
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/outline-core/package.json
+++ b/packages/outline-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-core",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Core functionality that is shared across all Outline Web Components",
   "keywords": [
     "outline",

--- a/packages/outline-core/src/controllers/light-dom-styles.ts
+++ b/packages/outline-core/src/controllers/light-dom-styles.ts
@@ -1,6 +1,68 @@
 /* eslint-disable no-console */
 import { ReactiveControllerHost, CSSResultGroup, CSSResult } from 'lit';
-import { addScopeToStyles } from '../internal/light-dom.mjs';
+import * as cssTools from '@adobe/css-tools';
+
+/**
+ * Helper function to add Scope to a specific CSS Selector.
+ * Handles :host and ::slotted conversions.
+ */
+const _scopeSelector = (selector: string, scopeId: string) => {
+  // Check if selector is already scoped.
+  if (selector.startsWith(scopeId)) {
+    return selector;
+  }
+  // Skip :root selectors.
+  else if (selector.includes(':root')) {
+    return selector;
+  }
+  // Convert ":host(Something)" to "ScopeSomething"
+  else if (selector.includes(':host(')) {
+    return selector.replace(/:host\((.+?)\)/, scopeId + '$1');
+  }
+  // Convert remaining ":host" to "Scope"
+  else if (selector.includes(':host')) {
+    return selector.replace(':host', scopeId);
+  }
+  // Convert "::slotted(Something)" to "Scope Something".
+  else if (selector.includes('::slotted(')) {
+    return selector.replace(/::slotted\((.+?)\)/, scopeId + ' $1');
+  }
+  // Otherwise, just prefix selector with Scope.
+  return scopeId + ' ' + selector;
+};
+
+/**
+ * Add scope to a single CSS rule.
+ */
+const _processCssRule = (rule: cssTools.CssAtRuleAST, scopeId: string) => {
+  if ('selectors' in rule && rule.selectors.length > 0) {
+    for (let i = 0; i < rule.selectors.length; i++) {
+      rule.selectors[i] = _scopeSelector(rule.selectors[i], scopeId);
+    }
+  } else if ('rules' in rule) {
+    // Handle rules that have recursive rules (such as media)
+    rule.rules.forEach((innerRule: cssTools.CssAtRuleAST) => {
+      _processCssRule(innerRule, scopeId);
+    });
+  }
+};
+
+/**
+ * Add the scopeId to each CSS rule selector.
+ * Handle the :host and ::slotted selectors.
+ */
+const addScopeToStyles = (cssStyles: string, scopeId: string) => {
+  // Use css-tools to parse the string into a tree.
+  const ast = cssTools.parse(cssStyles);
+  if (ast && ast.stylesheet && ast.stylesheet.rules.length > 0) {
+    ast.stylesheet.rules.forEach(function (rule: cssTools.CssAtRuleAST) {
+      _processCssRule(rule, scopeId);
+    });
+  }
+
+  // Convert tree back to a string and return the new css.
+  return cssTools.stringify(ast, { compress: true });
+};
 
 /**
  * The LightComStyles ReactiveController.

--- a/packages/outline-docs/CHANGELOG.md
+++ b/packages/outline-docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-docs
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.11
 
 ### Patch Changes

--- a/packages/outline-docs/package.json
+++ b/packages/outline-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-docs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Outline Documentation",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.11",
+    "@phase2/outline-core": "^0.2.0",
     "tslib": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/outline-dropdown/CHANGELOG.md
+++ b/packages/outline-dropdown/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @phase2/outline-dropdown
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-button@0.1.5
+  - @phase2/outline-icon@0.1.3
+  - @phase2/outline-link@0.1.5
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/outline-dropdown/package.json
+++ b/packages/outline-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-dropdown",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The Outline Components for the dropdown web component",
   "keywords": [
     "outline",
@@ -27,10 +27,10 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-button": "^0.1.4",
-    "@phase2/outline-core": "^0.1.10",
-    "@phase2/outline-icon": "^0.1.2",
-    "@phase2/outline-link": "^0.1.4",
+    "@phase2/outline-button": "^0.1.5",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-icon": "^0.1.3",
+    "@phase2/outline-link": "^0.1.5",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-examples/CHANGELOG.md
+++ b/packages/outline-examples/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-examples
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/outline-examples/package.json
+++ b/packages/outline-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-examples",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Examples of Outline component creation and usage",
   "keywords": [
     "outline",
@@ -26,7 +26,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-form/CHANGELOG.md
+++ b/packages/outline-form/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @phase2/outline-form
 
+## 0.1.0
+
+### Minor Changes
+
+- Updated lightDomStyles functionality for components
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/outline-form/package.json
+++ b/packages/outline-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-form",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "The Outline Components for the form component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.11",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-form/src/outline-form.ts
+++ b/packages/outline-form/src/outline-form.ts
@@ -12,7 +12,7 @@ import globalStyles from './outline-form.global.scoped.css.lit';
  */
 @customElement('outline-form')
 export class OutlineForm extends OutlineElement {
-  static styles: CSSResultGroup = [OutlineElement.styles, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
 
   lightDomStyles = new LightDomStyles(this, globalStyles);
 

--- a/packages/outline-grid/CHANGELOG.md
+++ b/packages/outline-grid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-grid
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/outline-grid/package.json
+++ b/packages/outline-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-grid",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The Outline Components for the grid web component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-heading/CHANGELOG.md
+++ b/packages/outline-heading/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-heading
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-heading/package.json
+++ b/packages/outline-heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-heading",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the web heading component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-icon/CHANGELOG.md
+++ b/packages/outline-icon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @phase2/outline-icon
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-include@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-icon/package.json
+++ b/packages/outline-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-icon",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the icon component",
   "keywords": [
     "outline",
@@ -28,8 +28,8 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
-    "@phase2/outline-include": "^0.1.2",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-include": "^0.1.3",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-image-slider/CHANGELOG.md
+++ b/packages/outline-image-slider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-image-slider
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/outline-image-slider/package.json
+++ b/packages/outline-image-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-image-slider",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The Outline Components for the image slider component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "@splidejs/splide": "^4.0.7",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"

--- a/packages/outline-image/CHANGELOG.md
+++ b/packages/outline-image/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-image
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-image/package.json
+++ b/packages/outline-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-image",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the image component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-include/CHANGELOG.md
+++ b/packages/outline-include/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-include
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-include/package.json
+++ b/packages/outline-include/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-include",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the include component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-link/CHANGELOG.md
+++ b/packages/outline-link/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-link
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-link/package.json
+++ b/packages/outline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-link",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web link component",
   "keywords": [
     "outline",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-list/CHANGELOG.md
+++ b/packages/outline-list/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @phase2/outline-list
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-heading@0.1.3
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/outline-list/package.json
+++ b/packages/outline-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-list",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The Outline Components for the web list component",
   "keywords": [
     "outline",
@@ -28,8 +28,8 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
-    "@phase2/outline-heading": "^0.1.2",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-heading": "^0.1.3",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-modal/CHANGELOG.md
+++ b/packages/outline-modal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-modal
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-modal/package.json
+++ b/packages/outline-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-modal",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web modal component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-storybook/CHANGELOG.md
+++ b/packages/outline-storybook/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @phase2/outline-storybook
 
+## 0.0.39
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-alert@0.1.7
+  - @phase2/outline-code-block@0.1.3
+  - @phase2/outline-docs@0.0.12
+
 ## 0.0.38
 
 ### Patch Changes

--- a/packages/outline-storybook/package.json
+++ b/packages/outline-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phase2/outline-storybook",
   "description": "Storybook integration for Outline",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "scripts": {
     "package": "yarn publish"
@@ -12,10 +12,10 @@
     "directory": "packages/outline-storybook"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.11",
-    "@phase2/outline-alert": "^0.1.6",
-    "@phase2/outline-code-block": "^0.1.1",
-    "@phase2/outline-docs": "^0.0.11",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-alert": "^0.1.7",
+    "@phase2/outline-code-block": "^0.1.3",
+    "@phase2/outline-docs": "^0.0.12",
     "@phase2/outline-static-assets": "^0.0.3"
   },
   "devDependencies": {

--- a/packages/outline-style-guide/CHANGELOG.md
+++ b/packages/outline-style-guide/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-style-guide
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/outline-style-guide/package.json
+++ b/packages/outline-style-guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-style-guide",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Web Components utilized primarily in a component style guide.",
   "keywords": [
     "outline",
@@ -26,7 +26,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.0.2",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-styled-text/CHANGELOG.md
+++ b/packages/outline-styled-text/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-styled-text
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/outline-styled-text/package.json
+++ b/packages/outline-styled-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-styled-text",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "The Outline Components for the web styled text component",
   "keywords": [
     "outline components",
@@ -27,7 +27,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-styled-text/src/outline-styled-text.ts
+++ b/packages/outline-styled-text/src/outline-styled-text.ts
@@ -12,7 +12,7 @@ import componentStyles from './outline-styled-text.css.lit';
  */
 @customElement('outline-styled-text')
 export class OutlineStyledText extends OutlineElement {
-  static styles: CSSResultGroup = [OutlineElement.styles, componentStyles];
+  static styles: CSSResultGroup = [componentStyles];
   slots = new SlotsController(this);
 
   render(): TemplateResult {

--- a/packages/outline-tabs/CHANGELOG.md
+++ b/packages/outline-tabs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @phase2/outline-tabs
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+  - @phase2/outline-accordion@0.1.5
+  - @phase2/outline-heading@0.1.3
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/outline-tabs/package.json
+++ b/packages/outline-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-tabs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Outline Components for the web tabs component",
   "keywords": [
     "outline components",
@@ -27,9 +27,9 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.10",
-    "@phase2/outline-accordion": "^0.1.4",
-    "@phase2/outline-heading": "^0.1.2",
+    "@phase2/outline-core": "^0.2.0",
+    "@phase2/outline-accordion": "^0.1.5",
+    "@phase2/outline-heading": "^0.1.3",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-video-vimeo/CHANGELOG.md
+++ b/packages/outline-video-vimeo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-video-vimeo
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-video-vimeo/package.json
+++ b/packages/outline-video-vimeo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-video-vimeo",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the web video vimeo component",
   "keywords": [
     "outline components",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/packages/outline-video-youtube/CHANGELOG.md
+++ b/packages/outline-video-youtube/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @phase2/outline-video-youtube
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @phase2/outline-core@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/outline-video-youtube/package.json
+++ b/packages/outline-video-youtube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase2/outline-video-youtube",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Outline Components for the web video youtube component",
   "keywords": [
     "outline components",
@@ -28,7 +28,7 @@
     "package": "yarn publish"
   },
   "dependencies": {
-    "@phase2/outline-core": "^0.1.9",
+    "@phase2/outline-core": "^0.2.0",
     "lit": "^2.3.1",
     "tslib": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@adobe/css-tools@^4.3.0-beta.2":
-  version "4.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.0-beta.2.tgz#b9554e285dde9ae2b1f748cd091373d7eb058573"
-  integrity sha512-VzekSqtYB+8XX8W1gNRIa1TbTXjVw64I5yLrbBP13JhwecixQzrpXWIszo7FghS9cm6FEFhzIivzwjns35DMlQ==
+  version "4.3.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.0-rc.1.tgz#20885a8bfe608512a9a191267b1df0017745e3fe"
+  integrity sha512-9QU7yHfQvQ++yc2zQlpu2eUcYgl7lIcAWPqLQ7X3mbKGK4ivMMuKQLRPQoKdbAdluDltb8Q49jGAVYcfsND0yA==
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"


### PR DESCRIPTION
## Description

Unblock all the things.
Causes duplicate code between `light-dom-styles.ts` (Controller) and `light-dom.mjs` (script) that should be addressed during a refactor.